### PR TITLE
fix(ansible): make workstation setup idempotent

### DIFF
--- a/config/private_dot_config/private_fish/private_fish_plugins
+++ b/config/private_dot_config/private_fish/private_fish_plugins
@@ -1,4 +1,3 @@
-jorgebucaran/fisher@4
 PatrickF1/fzf.fish
 oh-my-fish/theme-bobthefish
 acomagu/fish-async-prompt@a89bf4216b65170e4c3d403e7cbf24ce34b134e6

--- a/scripts/common/ansible/roles/fish/tasks/main.yaml
+++ b/scripts/common/ansible/roles/fish/tasks/main.yaml
@@ -67,7 +67,8 @@
           - fisher update
       when: >-
         download_result.changed or
-        fisher_plugins.stdout_lines !=
+        fisher_plugins.stdout_lines | map('lower') | list !=
         lookup('ansible.builtin.file', ansible_facts['user_dir'] + '/.config/fish/fish_plugins').splitlines()
+        | map('lower') | list
 
   tags: fish_config

--- a/scripts/common/ansible/roles/system_defaults/defaults/main.yaml
+++ b/scripts/common/ansible/roles/system_defaults/defaults/main.yaml
@@ -118,8 +118,6 @@ osx_alt_tab_defaults:
   - { name: "alt-tab | do not send crash reports", domain: com.lwouis.alt-tab-macos, key: crashPolicy, type: string, value: 0, state: present }
   - { name: "alt-tab | disable automatic updates", domain: com.lwouis.alt-tab-macos, key: SUAutomaticallyUpdate, type: bool, value: false, state: present }
   - { name: "alt-tab | disable automatic update checks", domain: com.lwouis.alt-tab-macos, key: SUEnableAutomaticChecks, type: bool, value: false, state: present }
-  # use lowercase `\u` to pass unicode
-  - { name: "alt-tab | set shortcuts #1", domain: com.lwouis.alt-tab-macos, key: holdShortcut, type: string, value: "\u2318", state: present }
 
 osx_rectangle_defaults:
   - { name: "rectangle | set spectacle-compatible shortcuts", domain: com.knollsoft.Rectangle, key: alternateDefaultShortcuts, type: int, value: 0, state: present }

--- a/scripts/common/ansible/roles/system_defaults/tasks/keybindings.yaml
+++ b/scripts/common/ansible/roles/system_defaults/tasks/keybindings.yaml
@@ -44,23 +44,94 @@
     != keyboard_modifier_mapping
   notify: apply keyboard modifier mapping
 
+- name: "read alt-tab preferences"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/defaults
+      - export
+      - com.lwouis.alt-tab-macos
+      - "-"
+  register: alt_tab_preferences
+  changed_when: false
+  failed_when: alt_tab_preferences.rc not in [0, 1]
+  check_mode: false
+
+- name: "read alt-tab shortcut"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/plutil
+      - -extract
+      - holdShortcut
+      - raw
+      - -o
+      - "-"
+      - --
+      - "-"
+    stdin: "{{ alt_tab_preferences.stdout }}"
+  register: alt_tab_shortcut
+  changed_when: false
+  failed_when: alt_tab_shortcut.rc not in [0, 1]
+  check_mode: false
+
+- name: "alt-tab | set shortcut"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/defaults
+      - write
+      - com.lwouis.alt-tab-macos
+      - holdShortcut
+      - -string
+      - "⌘"
+  when: alt_tab_shortcut.stdout != '⌘'
+
+- name: "read symbolic hotkeys preferences"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/defaults
+      - export
+      - com.apple.symbolichotkeys
+      - "-"
+  register: symbolic_hotkeys_preferences
+  changed_when: false
+  failed_when: symbolic_hotkeys_preferences.rc not in [0, 1]
+  check_mode: false
+
+- name: "read symbolic hotkeys"
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/plutil
+      - -extract
+      - AppleSymbolicHotKeys
+      - json
+      - -o
+      - "-"
+      - --
+      - "-"
+    stdin: "{{ symbolic_hotkeys_preferences.stdout }}"
+  register: current_symbolic_hotkeys
+  changed_when: false
+  failed_when: current_symbolic_hotkeys.rc not in [0, 1]
+  check_mode: false
+
 - name: "remap system shortcuts"
-  community.general.osx_defaults:
-    domain: com.apple.symbolichotkeys
-    key: AppleSymbolicHotKeys
-    type: dict
-    dict_mode: add
-    value: >-
-      {{
-        {
-          item.key | string: {
-            'enabled': item.value.enabled,
-            'value': {
-              'parameters': item.value.parameters,
-              'type': 'standard'
-            }
-          }
-        }
-      }}
+  ansible.builtin.command:
+    argv:
+      - /usr/bin/defaults
+      - write
+      - com.apple.symbolichotkeys
+      - AppleSymbolicHotKeys
+      - -dict-add
+      - "{{ item.key }}"
+      - "{{ symbolic_hotkey_plist }}"
   loop: "{{ darwin_hotkeys | dict2items }}"
+  when: >-
+    (current_symbolic_hotkeys.stdout | default('{}', true) | from_json)
+    [item.key | string] | default({})
+    != {
+      'enabled': item.value.enabled,
+      'value': {
+        'parameters': item.value.parameters,
+        'type': 'standard'
+      }
+    }
   notify: restart preference services

--- a/scripts/common/ansible/roles/system_defaults/vars/main.yaml
+++ b/scripts/common/ansible/roles/system_defaults/vars/main.yaml
@@ -11,3 +11,20 @@ keyboard_modifier_mapping_plist: >-
   <key>HIDKeyboardModifierMappingDst</key>
   <integer>{{ keyboard_key_codes.escape }}</integer>
   </dict>
+
+symbolic_hotkey_plist: >-
+  <dict>
+  <key>enabled</key>
+  <{{ item.value.enabled | ternary('true', 'false') }}/>
+  <key>value</key>
+  <dict>
+  <key>parameters</key>
+  <array>
+  {% for parameter in item.value.parameters %}
+  <integer>{{ parameter }}</integer>
+  {% endfor %}
+  </array>
+  <key>type</key>
+  <string>standard</string>
+  </dict>
+  </dict>


### PR DESCRIPTION
Fixes the five changes detected by the manual idempotence workflow:\n\n- stop Fisher and Chezmoi from rewriting the plugin manifest\n- compare Fisher plugin identities case-insensitively\n- manage the AltTab Unicode shortcut through normalized plist reads\n- manage nested symbolic hotkeys through native plist values\n\nValidated with repository checks and an Ansible macOS check-mode pass.