### PR TITLE
fix(docs): improve accessibility and build performance

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,6 +20,11 @@ on:
 permissions:
   contents: read
 
+env:
+  # The site is intentionally pinned to MkDocs 1.x; Material 9 is not
+  # compatible with the unreleased MkDocs 2 rewrite.
+  NO_MKDOCS_2_WARNING: "true"
+
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -29,6 +29,7 @@
     const themeButton = document.querySelector("[data-theme-toggle]");
     const searchButton = document.querySelector("[data-search-toggle]");
     const drawerButton = document.querySelector("[data-drawer-toggle]");
+    const searchForm = document.querySelector(".md-search__form");
     const searchClose = document.querySelector('.md-search .md-search__icon[for="__search"]');
     const searchToggle = document.querySelector("#__search");
     const drawerToggle = document.querySelector("#__drawer");
@@ -182,6 +183,18 @@
     searchClose?.setAttribute("aria-label", "Close search");
     searchClose?.setAttribute("role", "button");
     searchClose?.setAttribute("tabindex", "0");
+    if (searchForm && !searchForm.querySelector("[data-search-submit]")) {
+      const searchSubmit = document.createElement("button");
+      searchSubmit.type = "submit";
+      searchSubmit.className = "search-submit";
+      searchSubmit.dataset.searchSubmit = "";
+      searchSubmit.textContent = "Open first result";
+      searchForm.append(searchSubmit);
+    }
+    searchForm?.addEventListener("submit", (event) => {
+      event.preventDefault();
+      document.querySelector(".md-search-result__link")?.click();
+    }, { signal });
     activateOnKeyboard(searchButton);
     activateOnKeyboard(searchClose);
 
@@ -363,7 +376,6 @@
 
     if (shortcutFilter && shortcutQuery && shortcutClear && shortcutStatus && shortcutEmpty) {
       shortcutFilter.classList.add("is-ready");
-      shortcutFilter.addEventListener("submit", (event) => event.preventDefault(), { signal });
       shortcutQuery.addEventListener("input", syncShortcutFilter, { signal });
       shortcutQuery.addEventListener("keydown", (event) => {
         if (event.key !== "Escape" || !shortcutQuery.value) return;

--- a/docs/assets/stylesheets/mkdocs.css
+++ b/docs/assets/stylesheets/mkdocs.css
@@ -321,6 +321,29 @@ button.header-icon {
   font-size: 0.875rem;
 }
 
+.site-header .search-submit {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.site-header .search-submit:focus-visible {
+  z-index: 1;
+  top: 0.5rem;
+  right: 3rem;
+  width: auto;
+  height: 2.25rem;
+  clip-path: none;
+  border: 1px solid var(--accent-primary);
+  border-radius: 0.375rem;
+  padding: 0 var(--space-3);
+  background: var(--surface-secondary);
+  color: var(--text-primary);
+}
+
 .site-header .md-search__output {
   position: relative;
   inset: auto;

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,7 +1,7 @@
 <header class="site-header" data-site-header data-md-component="header">
   <div class="reading-progress" aria-hidden="true"><span data-reading-progress></span></div>
   <div class="header-inner">
-    <span class="brand-link" aria-label="Oleksandr Ponomarov">
+    <span class="brand-link">
       <span class="brand-full">~/oleksandr-ponomarov</span>
       <span class="brand-short" aria-hidden="true">~/op</span>
     </span>

--- a/docs/overrides/partials/progress.html
+++ b/docs/overrides/partials/progress.html
@@ -1,0 +1,6 @@
+<div
+  class="md-progress"
+  data-md-component="progress"
+  role="progressbar"
+  aria-label="Loading page"
+></div>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dotfiles.oponomarov.com/sitemap.xml

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -7,7 +7,7 @@ description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and
 
 <p class="page-lead">Choose the layer where the shortcut runs. Alacritty, the terminal application, sends many macOS-style shortcuts directly to tmux; fish adds command-line bindings; tmux commands use <kbd>Ctrl</kbd> + <kbd>A</kbd> as their prefix.</p>
 
-<form class="shortcut-filter" role="search" data-shortcut-filter data-mobile-toc-anchor>
+<div class="shortcut-filter" role="search" data-shortcut-filter data-mobile-toc-anchor>
   <label for="shortcut-query">Find a shortcut</label>
   <div class="shortcut-filter__search">
     <input id="shortcut-query" type="search" inputmode="search" autocomplete="off" placeholder="Search keys or actions" data-shortcut-query>
@@ -22,7 +22,7 @@ description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and
     <button type="button" aria-pressed="false" data-shortcut-scope="neovim">Neovim</button>
   </div>
   <p class="shortcut-filter__status" aria-live="polite" data-shortcut-status></p>
-</form>
+</div>
 
 <div class="context-help-source" hidden>
 <button class="context-help-trigger" type="button" aria-label="Open quick context" aria-controls="context-help" aria-haspopup="dialog" title="Quick context" data-context-open data-context-ui><span aria-hidden="true">?</span></button>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,17 @@ markdown_extensions:
 plugins:
   - search:
       lang: en
+  - minify:
+      minify_html: true
+      minify_css: true
+      minify_js: true
+      cache_safe: true
+      css_files:
+        - assets/stylesheets/design-system.css
+        - assets/stylesheets/mkdocs.css
+      js_files:
+        - assets/javascripts/syntax-highlight.js
+        - assets/javascripts/site-shell.js
 
 extra_css:
   - assets/stylesheets/design-system.css

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,3 +1,5 @@
+# Material 9.x requires MkDocs 1.x; do not upgrade to MkDocs 2 in place.
 mkdocs==1.6.1
 mkdocs-material-extensions==1.3.1
-mkdocs-material==9.5.49
+mkdocs-material==9.7.7
+mkdocs-minify-plugin==0.8.0


### PR DESCRIPTION
## Summary

- upgrade MkDocs Material to 9.7.7 and keep MkDocs pinned to the compatible 1.x line
- minify and fingerprint generated HTML, CSS, and JavaScript assets
- fix progress, branding, search, and shortcut-filter accessibility issues
- add robots.txt with sitemap discovery

## Verification

- `mkdocs build --strict --clean`
- `mise exec -- prek run --all-files`
- Pa11y across Home, Setup, Shortcuts, OpenCode, and 404: no issues
- Linkinator: all 37 internal and external links passed
- responsive and interactive Chromium checks at mobile, tablet, and desktop widths
- Lighthouse mobile: Performance 76, Accessibility 100, Best Practices 100, SEO 100