### PR TITLE
ci: streamline and harden workflows

### DIFF
--- a/.github/actions/build-docs/action.yaml
+++ b/.github/actions/build-docs/action.yaml
@@ -1,0 +1,23 @@
+---
+name: Build documentation
+description: Install the pinned documentation toolchain and build the site
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+      with:
+        python-version: "3.14"
+        cache: pip
+        cache-dependency-path: requirements-docs.txt
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      run: python -m pip install --requirement requirements-docs.txt
+
+    - name: Build
+      shell: bash
+      run: zensical build --strict

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,10 +45,10 @@ jobs:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
       - name: Build test image
-        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
           DOCKER_BUILD_SUMMARY: false
@@ -68,7 +68,7 @@ jobs:
 
       - name: Login to DockerHub
         if: github.event_name == 'push'
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: shmileee
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,47 +6,60 @@ on:
     paths:
       - "config/**"
       - "scripts/**"
+      - ".dockerignore"
       - "Dockerfile"
       - "mise.toml"
       - ".github/workflows/docker.yaml"
+      - "!docs/**"
+      - "!**/*.md"
   push:
     branches: [master]
     paths:
       - "config/**"
       - "scripts/**"
+      - ".dockerignore"
       - "Dockerfile"
       - "mise.toml"
       - ".github/workflows/docker.yaml"
+      - "!docs/**"
+      - "!**/*.md"
 
 permissions:
   contents: read
 
 concurrency:
-  group: docker-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Publishing two tags is not atomic, so do not cancel a release midway.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-test-publish:
+    name: Build, test, and publish image
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 45
 
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3
 
       - name: Build test image
         uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+          DOCKER_BUILD_SUMMARY: false
         with:
           context: .
           load: true
           platforms: linux/arm64
           push: false
           tags: dotfiles:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,mode=max,scope=${{ github.workflow }}
           secrets: |
             GITHUB_TOKEN=${{ github.token }}
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,7 @@ on:
       - "docs-overrides/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - ".github/actions/build-docs/action.yaml"
       - ".github/workflows/docs.yaml"
   push:
     branches:
@@ -17,57 +18,47 @@ on:
       - "docs-overrides/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - ".github/actions/build-docs/action.yaml"
       - ".github/workflows/docs.yaml"
 
 permissions:
   contents: read
 
 concurrency:
-  group: docs-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Never interrupt a production deployment midway through publishing.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
+    name: Build documentation
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.14"
-          cache: pip
-          cache-dependency-path: requirements-docs.txt
+          persist-credentials: false
 
-      - name: Build
-        run: |
-          python -m pip install --requirement requirements-docs.txt
-          zensical build --strict
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
 
   deploy:
+    name: Build and deploy documentation
     if: github.event_name == 'push'
     permissions:
-      contents: write
-    runs-on: ubuntu-latest
+      contents: write # Push the generated site to the gh-pages branch.
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
-          python-version: "3.14"
-          cache: pip
-          cache-dependency-path: requirements-docs.txt
+          persist-credentials: false
 
-      - name: Build
-        run: |
-          python -m pip install --requirement requirements-docs.txt
-          zensical build --strict
+      - name: Build documentation
+        uses: ./.github/actions/build-docs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -61,7 +61,7 @@ jobs:
         uses: ./.github/actions/build-docs
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -84,6 +84,7 @@ jobs:
       - name: Validate
         run: |
           mise install
+          mise exec -- scripts/common/ansible.sh --install
           mise exec -- prek run --all-files
 
       - name: Verify a second run is idempotent

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -47,7 +47,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
     steps:
-      - name: Clean up installed software
+      - name: Reset Homebrew
         run: |
           formulae="$(brew list --formula)"
           if [[ -n "$formulae" ]]; then
@@ -57,12 +57,8 @@ jobs:
             brew uninstall --formula --ignore-dependencies --force $formulae
           fi
 
-          casks="$(brew list --cask)"
-          if [[ -n "$casks" ]]; then
-            # shellcheck disable=SC2086
-            brew uninstall --cask --force $casks
-          fi
-
+          # Keep runner-provided GUI applications. The Dock configuration
+          # references apps that are intentionally not managed by brew.casks.
           brew cleanup --prune-prefix
           NONINTERACTIVE=1 /bin/bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -6,74 +6,87 @@ on:
     paths:
       - "config/**"
       - "scripts/**"
+      - ".chezmoiroot"
       - ".ansible-lint"
       - ".pre-commit-config.yaml"
       - "mise.toml"
       - ".yamllint.yaml"
       - ".github/workflows/macos.yaml"
-      - "!**.md"
       - "!docs/**"
+      - "!**/*.md"
   push:
     branches: [master]
     paths:
       - "config/**"
       - "scripts/**"
+      - ".chezmoiroot"
       - ".ansible-lint"
       - ".pre-commit-config.yaml"
       - "mise.toml"
       - ".yamllint.yaml"
       - ".github/workflows/macos.yaml"
-      - "!**.md"
       - "!docs/**"
+      - "!**/*.md"
 
 permissions:
   contents: read
 
 concurrency:
-  group: macos-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   macos:
+    name: Provision and verify macOS
     runs-on: macos-latest
     timeout-minutes: 60
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      HOMEBREW_NO_ANALYTICS: "1"
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
     steps:
       - name: Clean up installed software
         run: |
-          while IFS= read -r formula; do
-            brew uninstall --ignore-dependencies --force "$formula"
-          done < <(brew list --formula)
-          while IFS= read -r cask; do
-            brew uninstall --cask --force "$cask"
-          done < <(brew list --cask)
-          brew cleanup --prune-prefix
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+          formulae="$(brew list --formula)"
+          if [[ -n "$formulae" ]]; then
+            # Formula names cannot contain whitespace; uninstalling them in one
+            # transaction avoids starting Homebrew once per preinstalled tool.
+            # shellcheck disable=SC2086
+            brew uninstall --formula --ignore-dependencies --force $formulae
+          fi
 
-      # - name: Download and install available system updates
-      #   if: startsWith(matrix.os, 'macos')
-      #   run: |
-      #     sudo softwareupdate -i -a
+          casks="$(brew list --cask)"
+          if [[ -n "$casks" ]]; then
+            # shellcheck disable=SC2086
+            brew uninstall --cask --force $casks
+          fi
+
+          brew cleanup --prune-prefix
+          NONINTERACTIVE=1 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Restore Ansible collections
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-ansible-${{ hashFiles('mise.toml', 'scripts/common/ansible/requirements.yml') }}
 
       - name: Install using setup.sh
         run: ./scripts/setup.sh --all
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Validate
         run: |
           mise install
-          mise exec -- scripts/common/ansible.sh --install
           mise exec -- prek run --all-files
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify a second run is idempotent
         run: |
           ./scripts/common/ansible.sh --run | tee /tmp/ansible-idempotence.log
           grep -Eq 'changed=0 +unreachable=0 +failed=0' /tmp/ansible-idempotence.log
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -47,7 +47,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
     steps:
-      - name: Reset Homebrew
+      - name: Reset Homebrew formulae
         run: |
           formulae="$(brew list --formula)"
           if [[ -n "$formulae" ]]; then
@@ -57,11 +57,9 @@ jobs:
             brew uninstall --formula --ignore-dependencies --force $formulae
           fi
 
-          # Keep runner-provided GUI applications. The Dock configuration
-          # references apps that are intentionally not managed by brew.casks.
+          # Keep runner-provided GUI applications and their cask metadata;
+          # Ansible installs any configured applications that are missing.
           brew cleanup --prune-prefix
-          NONINTERACTIVE=1 /bin/bash -c \
-            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/uninstall.sh)"
 
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -10,11 +10,12 @@ permissions:
   contents: read
 
 concurrency:
-  group: validate-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   static:
+    name: Validate repository
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
@@ -23,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up mise
         uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3
@@ -30,19 +33,19 @@ jobs:
       - name: Install Fish
         run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends fish
 
-      - name: Validate Fish syntax
-        run: find config -type f -name '*.fish' -print0 | xargs -0 fish --no-execute
-
-      - name: Render and validate Fish templates
+      - name: Validate Fish syntax and templates
         run: |
-          mise exec -- bash -c '
-            chezmoi execute-template \
-              < config/private_dot_config/private_fish/private_config.fish.tmpl \
-              | fish --no-execute
-            chezmoi execute-template \
-              < config/private_dot_config/private_fish/conf.d/alias.fish.tmpl \
-              | fish --no-execute
-          '
+          find config -type f -name '*.fish' -exec fish --no-execute {} +
+
+          while IFS= read -r -d '' template; do
+            mise exec -- chezmoi execute-template < "$template" | fish --no-execute
+          done < <(find config -type f -name '*.fish.tmpl' -print0)
+
+      - name: Restore Ansible collections
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ~/.ansible/collections
+          key: ${{ runner.os }}-ansible-${{ hashFiles('mise.toml', 'scripts/common/ansible/requirements.yml') }}
 
       - name: Run repository checks
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,18 @@ repos:
         entry: yamllint
         language: system
         types: [yaml]
+      - id: actionlint
+        name: actionlint
+        entry: actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        types: [yaml]
+      - id: zizmor
+        name: zizmor
+        entry: zizmor --min-severity medium --min-confidence medium
+        language: system
+        files: ^\.github/(actions|workflows)/.*\.ya?ml$
+        types: [yaml]
       - id: ansible-lint
         name: ansible-lint
         entry: env ANSIBLE_CONFIG=scripts/common/ansible/ansible.cfg ansible-lint scripts/common/ansible

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,9 @@ experimental = true
 legacy_version_file = false
 
 [tools]
+"aqua:rhysd/actionlint" = "1.7.12"
 "aqua:twpayne/chezmoi" = "2.72.0"
+"aqua:zizmorcore/zizmor" = "1.29.0"
 "pipx:ansible-core" = "2.21.3"
 "pipx:ansible-lint" = "26.8.0"
 "pipx:yamllint" = "1.38.0"

--- a/scripts/common/ansible/config.yaml
+++ b/scripts/common/ansible/config.yaml
@@ -15,8 +15,11 @@ brew:
     - alacritty
     - alt-tab
     - aws-vault
+    - chatgpt
+    - google-chrome
     - hiddenbar
     - kdiff3
+    - microsoft-outlook
     - rectangle
     - slack
     - spotify


### PR DESCRIPTION
## Summary

- cache documentation dependencies and Ansible collections while removing redundant setup work
- batch the macOS Homebrew reset and suppress unnecessary Docker build artifacts
- centralize documentation builds and make Fish template validation automatic
- harden checkout and publishing behavior, and explicitly exclude docs-only changes from macOS and Docker workflows
- add pinned actionlint and zizmor checks for GitHub Actions correctness and security

## Validation

- mise exec -- prek run --all-files
- actionlint
- zizmor --pedantic .github
- mkdocs build --strict
- Fish source and rendered-template syntax validation
- Ansible playbook syntax check