### PR TITLE
feat(docs): migrate site build to Zensical

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,11 +20,6 @@ on:
 permissions:
   contents: read
 
-env:
-  # The site is intentionally pinned to MkDocs 1.x; Material 9 is not
-  # compatible with the unreleased MkDocs 2 rewrite.
-  NO_MKDOCS_2_WARNING: "true"
-
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -38,10 +33,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
       - name: Build
         run: |
           python -m pip install --requirement requirements-docs.txt
-          mkdocs build --strict
+          zensical build --strict
 
   deploy:
     if: github.event_name == 'push'
@@ -53,10 +55,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
       - name: Build
         run: |
           python -m pip install --requirement requirements-docs.txt
-          mkdocs build --strict
+          zensical build --strict
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4

--- a/README.md
+++ b/README.md
@@ -10,3 +10,22 @@ allowed to occur through Homebrew and each tool's native update workflow.
 [![macos](https://github.com/shmileee/dotfiles/actions/workflows/macos.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/macos.yaml)
 [![docker](https://github.com/shmileee/dotfiles/actions/workflows/docker.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/docker.yaml)
 [![validate](https://github.com/shmileee/dotfiles/actions/workflows/validate.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/validate.yaml)
+
+## Documentation development
+
+The documentation site uses Zensical. With `uv` installed, preview the pinned
+documentation environment locally with:
+
+```sh
+uv run --python 3.14 --with-requirements requirements-docs.txt \
+  zensical serve
+```
+
+Open <http://localhost:8000>. The preview rebuilds when documentation,
+configuration, template, CSS, or JavaScript files change. Run the same strict
+build as CI with:
+
+```sh
+uv run --python 3.14 --with-requirements requirements-docs.txt \
+  zensical build --strict
+```

--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -29,9 +29,6 @@
     const themeButton = document.querySelector("[data-theme-toggle]");
     const searchButton = document.querySelector("[data-search-toggle]");
     const drawerButton = document.querySelector("[data-drawer-toggle]");
-    const searchForm = document.querySelector(".md-search__form");
-    const searchClose = document.querySelector('.md-search .md-search__icon[for="__search"]');
-    const searchToggle = document.querySelector("#__search");
     const drawerToggle = document.querySelector("#__drawer");
     const primarySidebar = document.querySelector(".md-sidebar--primary");
     const drawerTocToggle = primarySidebar?.querySelector("#__toc");
@@ -128,22 +125,8 @@
       }, { signal });
     }
 
-    const activateOnKeyboard = (control) => {
-      control?.addEventListener(
-        "keydown",
-        (event) => {
-          if (event.key !== "Enter" && event.key !== " ") return;
-          event.preventDefault();
-          control.click();
-        },
-        { signal },
-      );
-    };
-
     const syncControls = () => {
-      const searchIsOpen = Boolean(searchToggle?.checked);
       const drawerIsOpen = Boolean(drawerToggle?.checked);
-      searchButton?.setAttribute("aria-expanded", String(searchIsOpen));
       drawerButton?.setAttribute("aria-expanded", String(drawerIsOpen));
       drawerButton?.setAttribute("aria-label", drawerIsOpen ? "Close navigation" : "Open navigation");
     };
@@ -180,23 +163,15 @@
       setTabbable(secondary, tocIsOpen);
     };
 
-    searchClose?.setAttribute("aria-label", "Close search");
-    searchClose?.setAttribute("role", "button");
-    searchClose?.setAttribute("tabindex", "0");
-    if (searchForm && !searchForm.querySelector("[data-search-submit]")) {
-      const searchSubmit = document.createElement("button");
-      searchSubmit.type = "submit";
-      searchSubmit.className = "search-submit";
-      searchSubmit.dataset.searchSubmit = "";
-      searchSubmit.textContent = "Open first result";
-      searchForm.append(searchSubmit);
-    }
-    searchForm?.addEventListener("submit", (event) => {
-      event.preventDefault();
-      document.querySelector(".md-search-result__link")?.click();
+    searchButton?.addEventListener("click", () => {
+      if (drawerToggle?.checked) {
+        drawerToggle.checked = false;
+        drawerToggle.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      document.querySelector("[data-md-component='search']")?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
     }, { signal });
-    activateOnKeyboard(searchButton);
-    activateOnKeyboard(searchClose);
 
     drawerButton?.addEventListener(
       "click",
@@ -208,20 +183,9 @@
       { signal },
     );
 
-    searchToggle?.addEventListener(
-      "change",
-      () => {
-        if (searchToggle.checked && drawerToggle?.checked) drawerToggle.checked = false;
-        syncControls();
-        syncDrawerFocus();
-      },
-      { signal },
-    );
-
     drawerToggle?.addEventListener(
       "change",
       () => {
-        if (drawerToggle.checked && searchToggle?.checked) searchToggle.checked = false;
         syncControls();
         syncDrawerFocus();
       },
@@ -249,11 +213,7 @@
         }
 
         if (event.key !== "Escape") return;
-        if (searchToggle?.checked) {
-          searchToggle.checked = false;
-          syncControls();
-          searchButton?.focus();
-        } else if (drawerToggle?.checked) {
+        if (drawerToggle?.checked) {
           drawerToggle.checked = false;
           syncControls();
           syncDrawerFocus();

--- a/docs/assets/stylesheets/mkdocs.css
+++ b/docs/assets/stylesheets/mkdocs.css
@@ -265,133 +265,7 @@ button.header-icon {
 }
 
 .site-header > .md-search {
-  position: fixed;
-  inset: 0;
-  z-index: 100;
-  width: auto;
-  height: 100vh;
-  height: 100dvh;
   display: none;
-  padding: clamp(4.5rem, 12vh, 8rem) var(--page-gutter) var(--space-8);
-  background: rgba(11, 18, 32, 0.72);
-  opacity: 1;
-  pointer-events: auto;
-}
-
-:root[data-theme="light"] .site-header > .md-search {
-  background: rgba(17, 24, 39, 0.42);
-}
-
-#__search:checked ~ .site-header > .md-search {
-  display: block;
-}
-
-.site-header .md-search__overlay {
-  position: absolute;
-  inset: 0;
-  display: block;
-  background: transparent;
-  cursor: default;
-}
-
-.site-header .md-search__inner {
-  position: relative;
-  top: auto;
-  right: auto;
-  left: auto;
-  width: min(100%, 42rem);
-  height: auto;
-  float: none;
-  margin: 0 auto;
-  overflow: visible;
-  opacity: 1;
-  transform: none;
-}
-
-.site-header .md-search__form {
-  height: 3.25rem;
-  border: 1px solid var(--border-default);
-  border-radius: 0.5rem 0.5rem 0 0;
-  background: var(--surface-secondary);
-  box-shadow: none;
-}
-
-.site-header .md-search__input {
-  height: 100%;
-  font-size: 0.875rem;
-}
-
-.site-header .search-submit {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
-
-.site-header .search-submit:focus-visible {
-  z-index: 1;
-  top: 0.5rem;
-  right: 3rem;
-  width: auto;
-  height: 2.25rem;
-  clip-path: none;
-  border: 1px solid var(--accent-primary);
-  border-radius: 0.375rem;
-  padding: 0 var(--space-3);
-  background: var(--surface-secondary);
-  color: var(--text-primary);
-}
-
-.site-header .md-search__output {
-  position: relative;
-  inset: auto;
-  height: 0;
-  max-height: none;
-  overflow: hidden;
-  border: 0 solid var(--border-default);
-  border-radius: 0 0 0.5rem 0.5rem;
-  background: var(--surface-secondary);
-  opacity: 1;
-  box-shadow: none;
-  transition: height 160ms ease-out;
-}
-
-.site-header .md-search__form:valid + .md-search__output {
-  height: min(65vh, 36rem);
-  border-width: 0 1px 1px;
-}
-
-.site-header .md-search__scrollwrap {
-  width: 100%;
-  height: 100%;
-  max-height: none;
-  overscroll-behavior: contain;
-  scrollbar-color: var(--border-default) transparent;
-}
-
-.site-header .md-search-result__article {
-  font-size: 0.75rem;
-  line-height: 1.6;
-}
-
-.site-header .md-search-result__article pre {
-  margin: var(--space-2) 0;
-}
-
-.site-header .md-search-result__article pre > code {
-  padding: var(--space-2) 0;
-  overflow-wrap: anywhere;
-  white-space: pre-wrap;
-}
-
-.site-header .md-search .md-search__icon[for="__search"] svg:first-child {
-  display: none;
-}
-
-.site-header .md-search .md-search__icon[for="__search"] svg:last-child {
-  display: block;
 }
 
 .md-container,
@@ -770,6 +644,14 @@ button.header-icon {
 
 .md-nav--secondary .md-nav {
   font-family: inherit;
+}
+
+/* Zensical wraps table-of-contents labels in .md-typeset. Keep those labels
+   on the navigation type scale instead of inheriting the article scale. */
+.md-nav .md-typeset {
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
 }
 
 .md-nav--secondary > .md-nav__title {

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,15 @@
 ---
 title: Home
 description: A reproducible Apple Silicon macOS workstation and Ubuntu ARM64 integration environment built with Ansible and chezmoi.
+tags:
+  - Overview
+  - macOS
+  - Ubuntu
+  - Ansible
+  - chezmoi
 hide:
   - toc
+  - tags
 ---
 
 <section class="docs-hero docs-hero--home" markdown>
@@ -20,12 +27,12 @@ hide:
   </dl>
 </section>
 
-<div class="context-help-source" hidden>
+<section class="context-help-source" hidden data-search-exclude>
 <button class="context-help-trigger" type="button" aria-label="Open quick context" aria-controls="context-help" aria-haspopup="dialog" title="Quick context" data-context-open data-context-ui><span aria-hidden="true">?</span></button>
 <dialog class="context-help" id="context-help" aria-labelledby="context-help-title" data-context-dialog data-context-ui>
 <div class="context-help__panel">
 <header class="context-help__header">
-  <div><p>Quick context</p><h2 id="context-help-title">Terms used on this page</h2></div>
+  <div><p>Quick context</p><h2 id="context-help-title" data-search-exclude>Terms used on this page</h2></div>
   <button type="button" aria-label="Close quick context" data-context-close><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="m4 4 8 8m0-8-8 8" /></svg></button>
 </header>
 <dl class="context-help__terms">
@@ -37,7 +44,7 @@ hide:
 </dl>
 </div>
 </dialog>
-</div>
+</section>
 
 <section class="home-overview" markdown>
 <div class="home-overview__summary" markdown>

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,18 +1,25 @@
 ---
 title: OpenCode configuration
 description: Local secrets, model routing, corporate overlays, and contextual notifications.
+tags:
+  - OpenCode
+  - AI tooling
+  - tmux
+  - chezmoi
+hide:
+  - tags
 ---
 
 # OpenCode + OmO
 
 <p class="page-lead" data-mobile-toc-anchor>chezmoi, the dotfile manager, manages the shared OpenCode configuration, Oh My OpenAgent routing, fish integration, and tmux notification plumbing. Secrets and company-specific endpoints stay local.</p>
 
-<div class="context-help-source" hidden>
+<section class="context-help-source" hidden data-search-exclude>
 <button class="context-help-trigger" type="button" aria-label="Open quick context" aria-controls="context-help" aria-haspopup="dialog" title="Quick context" data-context-open data-context-ui><span aria-hidden="true">?</span></button>
 <dialog class="context-help" id="context-help" aria-labelledby="context-help-title" data-context-dialog data-context-ui>
 <div class="context-help__panel">
 <header class="context-help__header">
-  <div><p>Quick context</p><h2 id="context-help-title">Terms used on this page</h2></div>
+  <div><p>Quick context</p><h2 id="context-help-title" data-search-exclude>Terms used on this page</h2></div>
   <button type="button" aria-label="Close quick context" data-context-close><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="m4 4 8 8m0-8-8 8" /></svg></button>
 </header>
 <dl class="context-help__terms">
@@ -25,7 +32,7 @@ description: Local secrets, model routing, corporate overlays, and contextual no
 </dl>
 </div>
 </dialog>
-</div>
+</section>
 
 ## What is managed
 

--- a/docs/overrides/partials/header.html
+++ b/docs/overrides/partials/header.html
@@ -1,14 +1,15 @@
 <header class="site-header" data-site-header data-md-component="header">
+  {% set homepage = nav.items | first %}
   <div class="reading-progress" aria-hidden="true"><span data-reading-progress></span></div>
   <div class="header-inner">
     <span class="brand-link">
       <span class="brand-full">~/oleksandr-ponomarov</span>
       <span class="brand-short" aria-hidden="true">~/op</span>
     </span>
-    <a class="docs-home{% if nav.homepage.active %} is-active{% endif %}" href="{{ nav.homepage.url | url }}"{% if nav.homepage.active %} aria-current="page"{% endif %}>Home</a>
+    <a class="docs-home{% if homepage.active %} is-active{% endif %}" href="{{ homepage.url | url }}"{% if homepage.active %} aria-current="page"{% endif %}>Home</a>
 
     <nav class="site-nav" aria-label="Primary navigation">
-      {% for nav_item in nav %}
+      {% for nav_item in nav.items %}
         {% if not loop.first %}
           <a href="{{ nav_item.url | url }}"{% if nav_item.active %} class="is-active" aria-current="page"{% endif %}>{{ nav_item.title }}</a>
         {% endif %}
@@ -27,9 +28,9 @@
       <a class="header-icon md-icon" href="https://github.com/shmileee/dotfiles" aria-label="View the dotfiles repository on GitHub">
         {% include ".icons/fontawesome/brands/github.svg" %}
       </a>
-      <label class="header-icon md-icon" for="__search" role="button" tabindex="0" aria-controls="__search" aria-expanded="false" aria-label="Search documentation" data-search-toggle>
+      <button class="header-icon md-icon" type="button" aria-haspopup="dialog" aria-label="Search documentation" data-search-toggle>
         {% include ".icons/material/magnify.svg" %}
-      </label>
+      </button>
       <button class="header-icon header-menu md-icon" type="button" aria-controls="__drawer" aria-expanded="false" aria-label="Open navigation" data-drawer-toggle>
         {% include ".icons/material/menu.svg" %}
       </button>

--- a/docs/overrides/partials/nav.html
+++ b/docs/overrides/partials/nav.html
@@ -1,4 +1,5 @@
 {% import "partials/nav-item.html" as item with context %}
+{% set homepage = nav.items | first %}
 {% set class = "md-nav md-nav--primary" %}
 {% if "navigation.tabs" in features %}
   {% set class = class ~ " md-nav--lifted" %}
@@ -8,13 +9,13 @@
 {% endif %}
 <nav class="{{ class }}" aria-label="{{ lang.t('nav') }}" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href="{{ config.extra.homepage | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-nav__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+    <a href="{{ config.extra.homepage | d(homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-nav__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
       {% include "partials/logo.html" %}
     </a>
     {{ config.site_name }}
   </label>
   <ul class="md-nav__list" data-md-scrollfix>
-    {% for nav_item in nav %}
+    {% for nav_item in nav.items %}
       {% set path = "__nav_" ~ loop.index %}
       {{ item.render(nav_item, path, 1) }}
     {% endfor %}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,14 @@
 ---
 title: Setup guide
 description: Review, install, customize, and reapply the workstation configuration.
+tags:
+  - Setup
+  - macOS
+  - Ubuntu
+  - Ansible
+  - chezmoi
+hide:
+  - tags
 ---
 
 # Set up a workstation
@@ -20,12 +28,12 @@ description: Review, install, customize, and reapply the workstation configurati
   </a>
 </nav>
 
-<div class="context-help-source" hidden>
+<section class="context-help-source" hidden data-search-exclude>
 <button class="context-help-trigger" type="button" aria-label="Open quick context" aria-controls="context-help" aria-haspopup="dialog" title="Quick context" data-context-open data-context-ui><span aria-hidden="true">?</span></button>
 <dialog class="context-help" id="context-help" aria-labelledby="context-help-title" data-context-dialog data-context-ui>
 <div class="context-help__panel">
 <header class="context-help__header">
-  <div><p>Quick context</p><h2 id="context-help-title">Terms used on this page</h2></div>
+  <div><p>Quick context</p><h2 id="context-help-title" data-search-exclude>Terms used on this page</h2></div>
   <button type="button" aria-label="Close quick context" data-context-close><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="m4 4 8 8m0-8-8 8" /></svg></button>
 </header>
 <dl class="context-help__terms">
@@ -38,7 +46,7 @@ description: Review, install, customize, and reapply the workstation configurati
 </dl>
 </div>
 </dialog>
-</div>
+</section>
 
 ## Before you begin
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,6 +1,15 @@
 ---
 title: Shortcut reference
 description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and Neovim.
+tags:
+  - Shortcuts
+  - macOS
+  - Alacritty
+  - fish
+  - tmux
+  - Neovim
+hide:
+  - tags
 ---
 
 # Keyboard shortcuts
@@ -24,12 +33,12 @@ description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and
   <p class="shortcut-filter__status" aria-live="polite" data-shortcut-status></p>
 </div>
 
-<div class="context-help-source" hidden>
+<section class="context-help-source" hidden data-search-exclude>
 <button class="context-help-trigger" type="button" aria-label="Open quick context" aria-controls="context-help" aria-haspopup="dialog" title="Quick context" data-context-open data-context-ui><span aria-hidden="true">?</span></button>
 <dialog class="context-help" id="context-help" aria-labelledby="context-help-title" data-context-dialog data-context-ui>
 <div class="context-help__panel">
 <header class="context-help__header">
-  <div><p>Quick context</p><h2 id="context-help-title">Terms used on this page</h2></div>
+  <div><p>Quick context</p><h2 id="context-help-title" data-search-exclude>Terms used on this page</h2></div>
   <button type="button" aria-label="Close quick context" data-context-close><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="m4 4 8 8m0-8-8 8" /></svg></button>
 </header>
 <dl class="context-help__terms">
@@ -42,7 +51,7 @@ description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and
 </dl>
 </div>
 </dialog>
-</div>
+</section>
 
 <p class="shortcut-filter-empty" data-shortcut-empty hidden>No shortcuts match this search.</p>
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,8 @@ nav:
 
 theme:
   name: material
+  # Preserve Material's DOM and visual defaults while moving to Zensical.
+  variant: classic
   custom_dir: docs/overrides
   palette:
     scheme: slate
@@ -23,6 +25,7 @@ theme:
     repo: fontawesome/brands/github
   features:
     - navigation.instant
+    - search.highlight
     - navigation.expand
     - content.code.copy
     - navigation.footer
@@ -51,17 +54,6 @@ markdown_extensions:
 plugins:
   - search:
       lang: en
-  - minify:
-      minify_html: true
-      minify_css: true
-      minify_js: true
-      cache_safe: true
-      css_files:
-        - assets/stylesheets/design-system.css
-        - assets/stylesheets/mkdocs.css
-      js_files:
-        - assets/javascripts/syntax-highlight.js
-        - assets/javascripts/site-shell.js
 
 extra_css:
   - assets/stylesheets/design-system.css

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,2 @@
-# Material 9.x requires MkDocs 1.x; do not upgrade to MkDocs 2 in place.
-mkdocs==1.6.1
-mkdocs-material-extensions==1.3.1
-mkdocs-material==9.7.7
-mkdocs-minify-plugin==0.8.0
+# Zensical replaces both MkDocs and Material for MkDocs.
+zensical==0.0.57


### PR DESCRIPTION
## Summary

- migrate the documentation build and deployment workflow from MkDocs to Zensical
- align custom overrides, styles, and JavaScript with Zensical while preserving the existing site appearance and behavior
- enable search highlighting, add page tags, and exclude hidden Quick Context content from the search index
- document the local Zensical preview workflow and pin the documentation dependencies

## Validation

- clean strict Zensical build
- generated search index and page metadata checks
- JavaScript syntax check
- actionlint
- yamllint
- repository pre-commit hooks