### PR TITLE
Refactor local macOS Ansible modules

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -56,3 +56,6 @@ jobs:
             ansible-playbook \
             --inventory "127.0.0.1," \
             --syntax-check scripts/common/ansible/main.yaml
+
+      - name: Test local Ansible module helpers
+        run: python3 -m unittest discover -s tests/unit -v

--- a/scripts/common/ansible/ansible.cfg
+++ b/scripts/common/ansible/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 library = ./library
+module_utils = ./module_utils
 retry_files_enabled = false
 callbacks_enabled = ansible.posix.profile_tasks, ansible.posix.timer
 stdout_callback = ansible.builtin.default

--- a/scripts/common/ansible/config.yaml
+++ b/scripts/common/ansible/config.yaml
@@ -79,7 +79,9 @@ dockitems:
   - name: Downloads
     path: "{{ ansible_facts['user_dir'] }}/Downloads"
     section: others
-    options: [--view, auto, --display, stack, --sort, dateadded]
+    view: auto
+    display: stack
+    sort: dateadded
 
 keyboard_key_codes:
   caps_lock: 30064771129

--- a/scripts/common/ansible/library/dock_items.py
+++ b/scripts/common/ansible/library/dock_items.py
@@ -5,80 +5,98 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 ---
 module: dock_items
-short_description: Reconcile the current user's macOS Dock items
+short_description: Reconcile the current user's macOS Dock
 description:
-  - Uses dockutil's documented tab-delimited list output as structured fields.
-  - Reads native Dock plist fields for folder display, view, and sort options.
-  - Rebuilds the Dock only when the ordered item definitions differ.
+  - Reconciles the exact ordered set of persistent Dock items.
+  - Parses dockutil's tab-delimited output and reads native plist fields for folder presentation.
+  - Validates every requested item before changing the Dock and attempts rollback after a failed rebuild.
+requirements:
+  - dockutil
 options:
   items:
-    description: Ordered Dock item definitions.
+    description: Exact ordered Dock item definitions.
     type: list
     elements: dict
     required: true
     suboptions:
       name:
-        description: Human-readable item name used by the playbook.
+        description: Optional human-readable label returned in diagnostics.
         type: str
-        required: false
       path:
-        description: Application, directory, or URL to add.
+        description: Absolute file path, home-relative path, file URL, or network URL.
         type: str
         required: true
       section:
-        description: Dock section.
+        description: Dock section in which to place the item.
         choices: [apps, others]
         type: str
         default: apps
-      options:
-        description: Additional dockutil arguments for this item.
-        type: list
-        elements: str
-        default: []
+      display:
+        description: Folder representation. Valid only for filesystem items in V(others).
+        choices: [stack, folder]
+        type: str
+      view:
+        description: Folder content view. Valid only for filesystem items in V(others).
+        choices: [auto, fan, grid, list]
+        type: str
+      sort:
+        description: Folder sort order. Valid only for filesystem items in V(others).
+        choices: [name, dateadded, datemodified, datecreated, kind]
+        type: str
 author:
   - dotfiles maintainers
 attributes:
   check_mode:
     support: full
+  diff_mode:
+    support: full
+platform:
+  - macos
 """
 
 EXAMPLES = r"""
-- name: Configure Dock
+- name: Configure the Dock
   dock_items:
     items:
-      - path: /Applications/Alacritty.app
-      - path: /Users/me/Downloads
+      - name: Terminal
+        path: /Applications/Alacritty.app
+      - name: Downloads
+        path: ~/Downloads
         section: others
-        options: [--view, auto, --display, stack]
+        view: auto
+        display: stack
+        sort: dateadded
 """
 
 RETURN = r"""
+items:
+  description: Normalized Dock items after reconciliation, or current items in check mode.
+  returned: always
+  type: list
+  elements: dict
 paths:
-  description: Normalized paths found after reconciliation.
+  description: Normalized paths after reconciliation, or current paths in check mode.
   returned: always
   type: list
   elements: str
+rollback:
+  description: Whether restoration of the previous Dock succeeded after a mutation failure.
+  returned: on failure after mutation
+  type: bool
 """
 
 import plistlib
-import subprocess
 from pathlib import Path
-from typing import Any
-from urllib.parse import unquote, urlsplit
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+from urllib.parse import urlsplit
 
 from ansible.module_utils.basic import AnsibleModule
-
-
-def invoke(module: AnsibleModule, argv: list[str]) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(argv, capture_output=True, check=False, text=True)
-    if result.returncode != 0:
-        module.fail_json(
-            msg="dockutil command failed",
-            rc=result.returncode,
-            stdout=result.stdout,
-            stderr=result.stderr,
-        )
-    return result
+from ansible.module_utils.dotfiles_macos import (
+    dock_option_arguments,
+    dock_states_match,
+    normalize_location,
+    parse_dockutil_output,
+)
 
 
 DISPLAY_VALUES = {0: "stack", 1: "folder"}
@@ -86,71 +104,160 @@ VIEW_VALUES = {0: "auto", 1: "fan", 2: "grid", 3: "list"}
 SORT_VALUES = {1: "name", 2: "dateadded", 3: "datemodified", 4: "datecreated", 5: "kind"}
 
 
-def normalized_path(url: str) -> str:
-    return unquote(urlsplit(url).path).rstrip("/")
+class DockError(Exception):
+    pass
 
 
-def plist_folder_options(plist_path: str) -> dict[str, dict[str, str]]:
-    with Path(plist_path).open("rb") as plist_file:
-        plist = plistlib.load(plist_file)
+class DockCommandError(DockError):
+    def __init__(self, argv: List[str], rc: int, stdout: str, stderr: str) -> None:
+        super().__init__("dockutil command failed")
+        self.argv = argv
+        self.rc = rc
+        self.stdout = stdout
+        self.stderr = stderr
 
+
+class DockStateError(DockError):
+    pass
+
+
+def run_dockutil(module: AnsibleModule, argv: List[str]) -> str:
+    rc, stdout, stderr = module.run_command(argv)
+    if rc != 0:
+        raise DockCommandError(argv, rc, stdout, stderr)
+    return stdout
+
+
+def folder_options(plist_paths: List[str]) -> Dict[str, Dict[str, str]]:
     options = {}
-    for tile in plist.get("persistent-others", []):
-        tile_data = tile.get("tile-data", {})
-        url = tile_data.get("file-data", {}).get("_CFURLString")
-        if not url:
-            continue
-        path = normalized_path(url)
-        options[path] = {
-            "display": DISPLAY_VALUES.get(tile_data.get("displayas", 0), "unknown"),
-            "view": VIEW_VALUES.get(tile_data.get("viewas", 0), "unknown"),
-            "sort": SORT_VALUES.get(tile_data.get("arrangement", 1), "unknown"),
-        }
+    for plist_path in sorted(set(plist_paths)):
+        try:
+            with Path(plist_path).open("rb") as plist_file:
+                plist = plistlib.load(plist_file)
+        except (OSError, plistlib.InvalidFileException, TypeError, ValueError) as error:
+            raise DockStateError(
+                "could not read Dock plist {0!r}: {1}".format(plist_path, error)
+            ) from error
+        if not isinstance(plist, dict):
+            raise DockStateError("Dock plist {0!r} is not a dictionary".format(plist_path))
+
+        for tile in plist.get("persistent-others", []):
+            tile_data = tile.get("tile-data", {})
+            url = tile_data.get("file-data", {}).get("_CFURLString")
+            if not url:
+                continue
+            options[normalize_location(url)] = {
+                "display": DISPLAY_VALUES.get(tile_data.get("displayas", 0), "unknown"),
+                "view": VIEW_VALUES.get(tile_data.get("viewas", 0), "unknown"),
+                "sort": SORT_VALUES.get(tile_data.get("arrangement", 1), "unknown"),
+            }
     return options
 
 
-def current_items(module: AnsibleModule, dockutil: str) -> list[dict[str, Any]]:
-    output = invoke(module, [dockutil, "--list"]).stdout
-    rows = []
-    plist_paths = set()
-    for line_number, line in enumerate(output.splitlines(), start=1):
-        fields = line.split("\t")
-        if len(fields) < 4:
-            module.fail_json(msg=f"Unexpected dockutil output on line {line_number}: {line!r}")
-        section = {"persistentApps": "apps", "persistentOthers": "others"}.get(fields[2])
-        if section is None:
-            module.fail_json(msg=f"Unexpected Dock section on line {line_number}: {fields[2]!r}")
-        rows.append({"path": normalized_path(fields[1]), "section": section})
-        plist_paths.add(fields[3])
+def current_items(module: AnsibleModule, dockutil: str) -> List[Dict[str, Any]]:
+    try:
+        rows = parse_dockutil_output(run_dockutil(module, [dockutil, "--list"]))
+    except ValueError as error:
+        raise DockStateError(str(error)) from error
 
-    folder_options = {}
-    for plist_path in plist_paths:
-        folder_options.update(plist_folder_options(plist_path))
-    for row in rows:
-        row["options"] = folder_options.get(row["path"], {})
-    return rows
+    presentation = folder_options([row["plist"] for row in rows if row["plist"]])
+    return [
+        {
+            "name": row["name"],
+            "path": row["path"],
+            "section": row["section"],
+            "options": presentation.get(row["path"], {}),
+        }
+        for row in rows
+    ]
 
 
-def desired_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def desired_items(module: AnsibleModule) -> List[Dict[str, Any]]:
     desired = []
-    for item in items:
-        option_pairs = zip(item["options"][::2], item["options"][1::2], strict=True)
-        options = {option.removeprefix("--"): value for option, value in option_pairs}
+    seen = set()
+    for index, item in enumerate(module.params["items"]):
+        path = normalize_location(item["path"])
+        options = {
+            key: item[key] for key in ("display", "view", "sort") if item.get(key) is not None
+        }
+        if path in seen:
+            module.fail_json(msg="items[{0}] duplicates Dock path {1!r}".format(index, path))
+        seen.add(path)
+        if options and item["section"] != "others":
+            module.fail_json(
+                msg="items[{0}] uses folder presentation outside section=others".format(index)
+            )
+        if options and urlsplit(path).scheme not in ("", "file"):
+            module.fail_json(msg="items[{0}] uses folder presentation for a URL".format(index))
         desired.append(
-            {"path": item["path"].rstrip("/"), "section": item["section"], "options": options}
+            {
+                "name": item.get("name"),
+                "path": path,
+                "section": item["section"],
+                "options": options,
+            }
         )
     return desired
 
 
-def states_match(current: list[dict[str, Any]], desired: list[dict[str, Any]]) -> bool:
-    if len(current) != len(desired):
-        return False
-    return all(
-        actual["path"] == expected["path"]
-        and actual["section"] == expected["section"]
-        and all(actual["options"].get(key) == value for key, value in expected["options"].items())
-        for actual, expected in zip(current, desired, strict=True)
-    )
+def add_arguments(dockutil: str, item: Mapping[str, Any]) -> List[str]:
+    argv = [dockutil, "--add", item["path"], "--position", "end"]
+    if item["section"] != "apps":
+        argv.extend(["--section", item["section"]])
+    argv.extend(dock_option_arguments(item.get("options", {})))
+    argv.append("--no-restart")
+    return argv
+
+
+def rebuild(module: AnsibleModule, dockutil: str, items: List[Mapping[str, Any]]) -> None:
+    run_dockutil(module, [dockutil, "--remove", "all", "--no-restart"])
+    for item in items:
+        run_dockutil(module, add_arguments(dockutil, item))
+
+
+def restore(
+    module: AnsibleModule, dockutil: str, previous: List[Mapping[str, Any]]
+) -> Tuple[bool, Optional[DockCommandError]]:
+    try:
+        rebuild(module, dockutil, previous)
+    except DockCommandError as error:
+        return False, error
+    return True, None
+
+
+def public_items(items: List[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "name": item.get("name"),
+            "path": item["path"],
+            "section": item["section"],
+            "options": dict(item.get("options", {})),
+        }
+        for item in items
+    ]
+
+
+def missing_filesystem_paths(items: List[Mapping[str, Any]]) -> List[str]:
+    return [
+        item["path"]
+        for item in items
+        if not urlsplit(item["path"]).scheme and not Path(item["path"]).exists()
+    ]
+
+
+def fail_for_dock_error(module: AnsibleModule, error: DockError, **kwargs: Any) -> None:
+    failure = {"msg": str(error)}
+    failure.update(kwargs)
+    if isinstance(error, DockCommandError):
+        failure.update(
+            {
+                "command": error.argv,
+                "rc": error.rc,
+                "stdout": error.stdout,
+                "stderr": error.stderr,
+            }
+        )
+    module.fail_json(**failure)
 
 
 def main() -> None:
@@ -164,40 +271,77 @@ def main() -> None:
                     "path": {"type": "str", "required": True},
                     "name": {"type": "str"},
                     "section": {"type": "str", "choices": ["apps", "others"], "default": "apps"},
-                    "options": {"type": "list", "elements": "str", "default": []},
+                    "display": {"type": "str", "choices": ["stack", "folder"]},
+                    "view": {"type": "str", "choices": ["auto", "fan", "grid", "list"]},
+                    "sort": {
+                        "type": "str",
+                        "choices": ["name", "dateadded", "datemodified", "datecreated", "kind"],
+                    },
                 },
             }
         },
         supports_check_mode=True,
     )
+
+    desired = desired_items(module)
     dockutil = module.get_bin_path("dockutil", required=not module.check_mode)
-    desired = desired_items(module.params["items"])
     if dockutil is None:
-        module.exit_json(changed=True, paths=[], msg="dockutil is not installed yet")
-
-    current = current_items(module, dockutil)
-    if states_match(current, desired) or module.check_mode:
+        after = public_items(desired)
         module.exit_json(
-            changed=not states_match(current, desired),
-            paths=[item["path"] for item in current],
-        )
-
-    invoke(module, [dockutil, "--remove", "all", "--no-restart"])
-    for item in module.params["items"]:
-        argv = [dockutil, "--add", item["path"], "--position", "end", *item["options"]]
-        if item["section"] != "apps":
-            argv.extend(["--section", item["section"]])
-        argv.append("--no-restart")
-        invoke(module, argv)
-
-    final = current_items(module, dockutil)
-    if not states_match(final, desired):
-        module.fail_json(
-            msg="Dock still differs after reconciliation",
             changed=True,
-            paths=[item["path"] for item in final],
+            items=[],
+            paths=[],
+            msg="dockutil is not installed; the Dock cannot be inspected in check mode",
+            diff={"before": None, "after": after},
         )
-    module.exit_json(changed=True, paths=[item["path"] for item in final])
+
+    try:
+        current = current_items(module, dockutil)
+    except DockError as error:
+        fail_for_dock_error(module, error, changed=False)
+    before = public_items(current)
+    after = public_items(desired)
+    changed = not dock_states_match(current, desired)
+    result = {
+        "changed": changed,
+        "items": before if module.check_mode else after,
+        "paths": [item["path"] for item in (current if module.check_mode else desired)],
+        "diff": {"before": before, "after": after},
+    }
+    if not changed or module.check_mode:
+        module.exit_json(**result)
+
+    missing = missing_filesystem_paths(desired)
+    if missing:
+        module.fail_json(
+            msg="Refusing to rebuild the Dock because desired filesystem items do not exist",
+            changed=False,
+            missing=missing,
+        )
+
+    try:
+        rebuild(module, dockutil, desired)
+        persisted = current_items(module, dockutil)
+        if not dock_states_match(persisted, desired):
+            raise DockStateError(
+                "Dock state did not match the requested state after rebuilding"
+            )
+    except DockError as error:
+        rollback, rollback_error = restore(module, dockutil, current)
+        failure = {
+            "changed": True,
+            "rollback": rollback,
+        }
+        if rollback_error is not None:
+            failure["rollback_error"] = {
+                "command": rollback_error.argv,
+                "rc": rollback_error.rc,
+                "stdout": rollback_error.stdout,
+                "stderr": rollback_error.stderr,
+            }
+        fail_for_dock_error(module, error, **failure)
+
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/scripts/common/ansible/library/macos_defaults_plist.py
+++ b/scripts/common/ansible/library/macos_defaults_plist.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 DOCUMENTATION = r"""
 ---
 module: macos_defaults_plist
-short_description: Manage macOS defaults containing nested plist values
+short_description: Reconcile a structured macOS preference value
 description:
-  - Reads exported defaults with Python's plist parser instead of parsing human-readable output.
-  - Replaces a value or merges dictionary members without overwriting unrelated members.
+  - Reads a defaults domain as a plist instead of parsing human-readable output.
+  - Replaces scalar and collection values or shallow-merges dictionary members.
+  - Verifies the persisted value after every change.
 options:
   domain:
-    description: Defaults domain.
+    description: Defaults domain to manage.
     type: str
     required: true
   key:
-    description: Preference key.
+    description: Preference key to manage.
     type: str
     required: true
   value:
@@ -23,17 +24,20 @@ options:
     type: raw
     required: true
   value_type:
-    description: Type passed to defaults when replacing a value.
+    description: Plist type used to normalize and write O(value).
     choices: [string, bool, int, float, array, dict]
     type: str
     required: true
   current_host:
-    description: Use the current-host preference domain.
+    description: Address the current-host preference domain.
     type: bool
     default: false
   dict_mode:
-    description: Replace the dictionary or merge only desired members.
-    choices: [replace, add]
+    description:
+      - Controls dictionary reconciliation.
+      - V(replace) makes the complete dictionary match O(value).
+      - V(merge) preserves keys not present in O(value).
+    choices: [replace, merge]
     type: str
     default: replace
 author:
@@ -41,102 +45,140 @@ author:
 attributes:
   check_mode:
     support: full
+  diff_mode:
+    support: full
+platform:
+  - macos
 """
 
 EXAMPLES = r"""
-- name: Merge symbolic hotkeys
+- name: Merge symbolic hotkeys while preserving unrelated shortcuts
   macos_defaults_plist:
     domain: com.apple.symbolichotkeys
     key: AppleSymbolicHotKeys
     value_type: dict
-    dict_mode: add
+    dict_mode: merge
     value:
       "64":
         enabled: true
+
+- name: Configure the current host's modifier mapping
+  macos_defaults_plist:
+    domain: NSGlobalDomain
+    current_host: true
+    key: com.apple.keyboard.modifiermapping.0-0-0
+    value_type: array
+    value:
+      - HIDKeyboardModifierMappingSrc: 30064771129
+        HIDKeyboardModifierMappingDst: 30064771113
 """
 
-RETURN = r"""{}"""
+RETURN = r"""
+before:
+  description: Preference state before reconciliation.
+  returned: always
+  type: dict
+  contains:
+    exists:
+      description: Whether the preference key existed before reconciliation.
+      type: bool
+      returned: always
+    value:
+      description: Previous preference value.
+      type: raw
+      returned: when the key exists
+after:
+  description: Expected or persisted preference state after reconciliation.
+  returned: always
+  type: dict
+  contains:
+    exists:
+      description: Whether the preference key is expected to exist after reconciliation.
+      type: bool
+      returned: always
+    value:
+      description: Expected or persisted preference value.
+      type: raw
+      returned: always
+"""
 
 import plistlib
-import subprocess
-import xml.etree.ElementTree as element_tree
+from typing import Any, Dict, List
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.dotfiles_macos import (
+    json_safe_plist,
+    merged_mapping,
+    normalize_plist_value,
+    plist_fragment,
+)
 
 
 MISSING = object()
 
 
-def base_argv(module: AnsibleModule) -> list[str]:
-    argv = ["/usr/bin/defaults"]
-    if module.params["current_host"]:
+def preference_state(value: Any) -> Dict[str, Any]:
+    if value is MISSING:
+        return {"exists": False}
+    return {"exists": True, "value": json_safe_plist(value)}
+
+
+def defaults_argv(defaults: str, current_host: bool) -> List[str]:
+    argv = [defaults]
+    if current_host:
         argv.append("-currentHost")
     return argv
 
 
-def exported_domain(module: AnsibleModule) -> dict:
-    argv = [*base_argv(module), "export", module.params["domain"], "-"]
-    result = subprocess.run(argv, capture_output=True, check=False)
-    if result.returncode == 1:
-        return {}
-    if result.returncode != 0:
-        module.fail_json(msg="Could not export defaults domain", rc=result.returncode, stderr=result.stderr.decode())
+def export_domain(module: AnsibleModule, defaults: str) -> Dict[str, Any]:
+    argv = defaults_argv(defaults, module.params["current_host"])
+    argv.extend(["export", module.params["domain"], "-"])
+    rc, stdout, stderr = module.run_command(argv, encoding=None)
+    stderr_text = stderr.decode("utf-8", "replace")
+    if rc != 0:
+        missing_markers = ("does not exist", "not found", "domain/default pair")
+        if rc == 1 and any(marker in stderr_text.lower() for marker in missing_markers):
+            return {}
+        module.fail_json(
+            msg="Could not export defaults domain",
+            command=argv,
+            rc=rc,
+            stderr=stderr_text,
+        )
+
     try:
-        return plistlib.loads(result.stdout)
-    except plistlib.InvalidFileException as error:
-        module.fail_json(msg=f"Could not parse exported defaults domain: {error}")
+        domain = plistlib.loads(stdout)
+    except (plistlib.InvalidFileException, TypeError, ValueError) as error:
+        module.fail_json(msg="Could not parse exported defaults domain: {0}".format(error))
+    if not isinstance(domain, dict):
+        module.fail_json(msg="Exported defaults domain is not a dictionary")
+    return domain
 
 
-def fragment(value: object) -> str:
-    document = plistlib.dumps([value], fmt=plistlib.FMT_XML)
-    root = element_tree.fromstring(document)
-    array = root.find("array")
-    if array is None or len(array) != 1:
-        raise ValueError("Could not serialize plist value")
-    return element_tree.tostring(array[0], encoding="unicode")
+def write_arguments(value: Any, value_type: str) -> List[str]:
+    if value_type == "dict":
+        return ["-dict"] + [
+            part for key, item in value.items() for part in (str(key), plist_fragment(item))
+        ]
+    if value_type == "array":
+        return ["-array"] + [plist_fragment(item) for item in value]
+    serialized = str(value).lower() if value_type == "bool" else str(value)
+    return ["-{0}".format(value_type), serialized]
 
 
-def differs(current: object, desired: object, value_type: str, dict_mode: str) -> bool:
-    if current is MISSING:
-        return True
-    if value_type == "dict" and dict_mode == "add":
-        return not isinstance(current, dict) or any(current.get(key, MISSING) != value for key, value in desired.items())
-    return current != desired
-
-
-def normalized_value(value: object, value_type: str) -> object:
-    if value_type == "string":
-        return str(value)
-    if value_type == "bool":
-        return bool(value)
-    if value_type == "int":
-        return int(value)
-    if value_type == "float":
-        return float(value)
-    return value
-
-
-def write_value(module: AnsibleModule) -> None:
-    value = module.params["value"]
-    value_type = module.params["value_type"]
-    argv = [*base_argv(module), "write", module.params["domain"], module.params["key"]]
-    commands: list[list[str]] = []
-
-    if value_type == "dict" and module.params["dict_mode"] == "add":
-        commands = [[*argv, "-dict-add", str(key), fragment(item)] for key, item in value.items()]
-    elif value_type == "array":
-        commands = [[*argv, "-array", *[fragment(item) for item in value]]]
-    elif value_type == "dict":
-        flattened = [part for key, item in value.items() for part in (str(key), fragment(item))]
-        commands = [[*argv, "-dict", *flattened]]
-    else:
-        scalar = str(value).lower() if value_type == "bool" else str(value)
-        commands = [[*argv, f"-{value_type}", scalar]]
-
-    for command in commands:
-        result = subprocess.run(command, capture_output=True, check=False, text=True)
-        if result.returncode != 0:
-            module.fail_json(msg="Could not write defaults value", rc=result.returncode, stderr=result.stderr)
+def write_preference(module: AnsibleModule, defaults: str, value: Any) -> None:
+    argv = defaults_argv(defaults, module.params["current_host"])
+    argv.extend(["write", module.params["domain"], module.params["key"]])
+    argv.extend(write_arguments(value, module.params["value_type"]))
+    rc, stdout, stderr = module.run_command(argv)
+    if rc != 0:
+        module.fail_json(
+            msg="Could not write defaults value",
+            command=argv,
+            rc=rc,
+            stdout=stdout,
+            stderr=stderr,
+        )
 
 
 def main() -> None:
@@ -151,23 +193,51 @@ def main() -> None:
                 "required": True,
             },
             "current_host": {"type": "bool", "default": False},
-            "dict_mode": {"type": "str", "choices": ["replace", "add"], "default": "replace"},
+            "dict_mode": {"type": "str", "choices": ["replace", "merge"], "default": "replace"},
         },
         supports_check_mode=True,
     )
-    domain = exported_domain(module)
-    desired = normalized_value(module.params["value"], module.params["value_type"])
-    module.params["value"] = desired
-    current = domain.get(module.params["key"], MISSING)
-    drift = differs(current, desired, module.params["value_type"], module.params["dict_mode"])
-    if not drift or module.check_mode:
-        module.exit_json(changed=drift)
 
-    write_value(module)
-    final = exported_domain(module).get(module.params["key"], MISSING)
-    if differs(final, desired, module.params["value_type"], module.params["dict_mode"]):
-        module.fail_json(msg="Default still differs after reconciliation", changed=True)
-    module.exit_json(changed=True)
+    if module.params["dict_mode"] == "merge" and module.params["value_type"] != "dict":
+        module.fail_json(msg="dict_mode=merge requires value_type=dict")
+
+    try:
+        desired_input = normalize_plist_value(module.params["value"], module.params["value_type"])
+    except ValueError as error:
+        module.fail_json(msg="Invalid value: {0}".format(error))
+
+    defaults = module.get_bin_path("defaults", required=True)
+    domain = export_domain(module, defaults)
+    current = domain.get(module.params["key"], MISSING)
+    desired = (
+        merged_mapping(current, desired_input)
+        if module.params["value_type"] == "dict" and module.params["dict_mode"] == "merge"
+        else desired_input
+    )
+    changed = current is MISSING or current != desired
+    before = preference_state(current)
+    after = preference_state(desired)
+    result = {
+        "changed": changed,
+        "before": before,
+        "after": after,
+        "diff": {"before": before, "after": after},
+    }
+
+    if not changed or module.check_mode:
+        module.exit_json(**result)
+
+    write_preference(module, defaults, desired)
+    persisted = export_domain(module, defaults).get(module.params["key"], MISSING)
+    if persisted is MISSING or persisted != desired:
+        module.fail_json(
+            msg="Preference still differs after reconciliation",
+            changed=True,
+            before=before,
+            after=preference_state(persisted),
+            expected=after,
+        )
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/scripts/common/ansible/module_utils/dotfiles_macos.py
+++ b/scripts/common/ansible/module_utils/dotfiles_macos.py
@@ -1,0 +1,160 @@
+"""Pure helpers shared by the dotfiles macOS Ansible modules.
+
+This file deliberately has no Ansible imports. Keeping normalization and
+comparison code independent makes it usable from module code and inexpensive
+to test with the Python standard library.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import plistlib
+import posixpath
+import xml.etree.ElementTree as element_tree
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+
+def normalize_plist_value(value: Any, value_type: str) -> Any:
+    """Coerce a module value and verify that plistlib can serialize it."""
+    if value_type == "string":
+        normalized = str(value)
+    elif value_type == "bool":
+        if not isinstance(value, bool):
+            raise ValueError("a bool value must be true or false")
+        normalized = value
+    elif value_type == "int":
+        if isinstance(value, bool):
+            raise ValueError("an int value cannot be a boolean")
+        try:
+            normalized = int(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("an int value must be an integer") from error
+    elif value_type == "float":
+        if isinstance(value, bool):
+            raise ValueError("a float value cannot be a boolean")
+        try:
+            normalized = float(value)
+        except (TypeError, ValueError) as error:
+            raise ValueError("a float value must be numeric") from error
+    elif value_type == "array":
+        if not isinstance(value, list):
+            raise ValueError("an array value must be a list")
+        normalized = value
+    elif value_type == "dict":
+        if not isinstance(value, dict):
+            raise ValueError("a dict value must be a mapping")
+        normalized = value
+    else:
+        raise ValueError("unsupported plist value type: {0}".format(value_type))
+
+    try:
+        plistlib.dumps([normalized], fmt=plistlib.FMT_XML, sort_keys=False)
+    except (TypeError, ValueError) as error:
+        raise ValueError("value is not plist-serializable: {0}".format(error)) from error
+    return normalized
+
+
+def plist_fragment(value: Any) -> str:
+    """Serialize one value in the XML form accepted by ``defaults``."""
+    document = plistlib.dumps([value], fmt=plistlib.FMT_XML, sort_keys=False)
+    root = element_tree.fromstring(document)
+    array = root.find("array")
+    if array is None or len(array) != 1:
+        raise ValueError("could not serialize plist value")
+    return element_tree.tostring(array[0], encoding="unicode")
+
+
+def merged_mapping(current: Any, desired: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a shallow plist dictionary merge without mutating either input."""
+    merged = dict(current) if isinstance(current, dict) else {}
+    merged.update(desired)
+    return merged
+
+
+def json_safe_plist(value: Any) -> Any:
+    """Convert native plist-only values into explicit JSON-safe representations."""
+    if isinstance(value, bytes):
+        return {"__plist_data__": base64.b64encode(value).decode("ascii")}
+    if isinstance(value, datetime.datetime):
+        return {"__plist_date__": value.isoformat()}
+    if isinstance(value, str):
+        return value.encode("utf-8", "replace").decode("utf-8")
+    if isinstance(value, dict):
+        return {json_safe_plist(key): json_safe_plist(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [json_safe_plist(item) for item in value]
+    return value
+
+
+def normalize_location(value: str) -> str:
+    """Normalize file paths and URLs without losing URL scheme or authority."""
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.scheme != "file":
+        path = posixpath.normpath(unquote(parsed.path or "/"))
+        if parsed.path.endswith("/") and path != "/":
+            path += "/"
+        return urlunsplit((parsed.scheme.lower(), parsed.netloc, path, parsed.query, parsed.fragment))
+
+    path = unquote(parsed.path) if parsed.scheme == "file" else value
+    expanded = str(Path(path).expanduser())
+    return expanded if expanded == "/" else expanded.rstrip("/")
+
+
+def parse_dockutil_output(output: str) -> List[Dict[str, str]]:
+    """Parse dockutil's documented tab-delimited list format."""
+    sections = {"persistentApps": "apps", "persistentOthers": "others"}
+    items = []
+    for line_number, line in enumerate(output.splitlines(), start=1):
+        if not line.strip():
+            continue
+        fields = line.split("\t")
+        if len(fields) < 4:
+            raise ValueError(
+                "unexpected dockutil output on line {0}: {1!r}".format(line_number, line)
+            )
+        section = sections.get(fields[2])
+        if section is None:
+            raise ValueError(
+                "unexpected Dock section on line {0}: {1!r}".format(line_number, fields[2])
+            )
+        items.append(
+            {
+                "name": fields[0],
+                "path": normalize_location(fields[1]),
+                "section": section,
+                "plist": fields[3],
+            }
+        )
+    return items
+
+
+def dock_states_match(
+    current: Iterable[Mapping[str, Any]], desired: Iterable[Mapping[str, Any]]
+) -> bool:
+    """Compare ordered Dock state, ignoring unspecified folder presentation."""
+    current_list = list(current)
+    desired_list = list(desired)
+    if len(current_list) != len(desired_list):
+        return False
+
+    for actual, expected in zip(current_list, desired_list):
+        if actual["path"] != expected["path"] or actual["section"] != expected["section"]:
+            return False
+        expected_options = expected.get("options", {})
+        actual_options = actual.get("options", {})
+        if any(actual_options.get(key) != value for key, value in expected_options.items()):
+            return False
+    return True
+
+
+def dock_option_arguments(options: Mapping[str, str]) -> List[str]:
+    """Convert typed folder presentation options to stable dockutil arguments."""
+    arguments = []
+    for name in ("view", "display", "sort"):
+        value = options.get(name)
+        if value is not None:
+            arguments.extend(["--{0}".format(name), value])
+    return arguments

--- a/scripts/common/ansible/roles/system_defaults/defaults/main.yaml
+++ b/scripts/common/ansible/roles/system_defaults/defaults/main.yaml
@@ -108,7 +108,7 @@ osx_global_defaults:
   - { name: "don't open imagecapture when camera plugged in", domain: com.apple.ImageCapture, key: disableHotPlug, type: boolean, value: true }
 
 osx_alt_tab_defaults:
-  - { name: "alt-tab | set shortcut", domain: com.lwouis.alt-tab-macos, key: holdShortcut, type: dict, value: { string: "⌘" }, dict_mode: add, state: present }
+  - { name: "alt-tab | set shortcut", domain: com.lwouis.alt-tab-macos, key: holdShortcut, type: dict, value: { string: "⌘" }, dict_mode: merge, state: present }
   - { name: "alt-tab | use the medium appearance", domain: com.lwouis.alt-tab-macos, key: appearanceSize, type: string, value: "1", state: present }
   - { name: "alt-tab | show windows from screen showing alt-tab", domain: com.lwouis.alt-tab-macos, key: screensToShow, type: string, value: 1, state: present }
   - { name: "alt-tab | show on the screen containing the pointer", domain: com.lwouis.alt-tab-macos, key: showOnScreen, type: string, value: "1", state: present }

--- a/scripts/common/ansible/roles/system_defaults/tasks/keybindings.yaml
+++ b/scripts/common/ansible/roles/system_defaults/tasks/keybindings.yaml
@@ -14,6 +14,6 @@
     domain: com.apple.symbolichotkeys
     key: AppleSymbolicHotKeys
     value_type: dict
-    dict_mode: add
+    dict_mode: merge
     value: "{{ darwin_hotkeys }}"
   notify: restart preference services

--- a/tests/unit/test_dotfiles_macos.py
+++ b/tests/unit/test_dotfiles_macos.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ANSIBLE_DIR = Path(__file__).parents[2] / "scripts" / "common" / "ansible"
+sys.path.insert(0, str(ANSIBLE_DIR / "module_utils"))
+
+from dotfiles_macos import (  # noqa: E402
+    dock_option_arguments,
+    dock_states_match,
+    json_safe_plist,
+    merged_mapping,
+    normalize_location,
+    normalize_plist_value,
+    parse_dockutil_output,
+    plist_fragment,
+)
+
+
+class PlistHelpersTest(unittest.TestCase):
+    def test_normalizes_scalars_without_bool_integer_confusion(self):
+        self.assertEqual(normalize_plist_value("7", "int"), 7)
+        self.assertEqual(normalize_plist_value(1, "string"), "1")
+        self.assertEqual(normalize_plist_value("0.5", "float"), 0.5)
+        self.assertIs(normalize_plist_value(False, "bool"), False)
+        with self.assertRaisesRegex(ValueError, "cannot be a boolean"):
+            normalize_plist_value(True, "int")
+        with self.assertRaisesRegex(ValueError, "must be true or false"):
+            normalize_plist_value("false", "bool")
+
+    def test_rejects_wrong_collection_types_and_invalid_plists(self):
+        with self.assertRaisesRegex(ValueError, "must be a list"):
+            normalize_plist_value({}, "array")
+        with self.assertRaisesRegex(ValueError, "must be a mapping"):
+            normalize_plist_value([], "dict")
+        with self.assertRaisesRegex(ValueError, "plist-serializable"):
+            normalize_plist_value({"bad": object()}, "dict")
+
+    def test_merges_without_mutating_current_mapping(self):
+        current = {"keep": 1, "change": 1}
+        desired = merged_mapping(current, {"change": 2})
+        self.assertEqual(desired, {"keep": 1, "change": 2})
+        self.assertEqual(current, {"keep": 1, "change": 1})
+
+    def test_serializes_nested_plist_fragment(self):
+        fragment = plist_fragment({"enabled": True, "values": [1, 2]})
+        self.assertIn("<dict>", fragment)
+        self.assertIn("<true", fragment)
+        self.assertIn("<array>", fragment)
+
+    def test_makes_binary_plist_data_safe_for_ansible_json(self):
+        self.assertEqual(
+            json_safe_plist({"secureData": b"\xd4\x00", "string": "⌘"}),
+            {"secureData": {"__plist_data__": "1AA="}, "string": "⌘"},
+        )
+
+
+class DockHelpersTest(unittest.TestCase):
+    def test_normalizes_paths_file_urls_and_network_urls(self):
+        self.assertEqual(normalize_location("/Applications/Test.app/"), "/Applications/Test.app")
+        self.assertEqual(normalize_location("file:///Users/me/My%20Folder/"), "/Users/me/My Folder")
+        self.assertEqual(
+            normalize_location("HTTPS://example.test/a%20folder/"),
+            "https://example.test/a folder/",
+        )
+
+    def test_parses_dockutil_rows(self):
+        output = (
+            "Terminal\t/Applications/Terminal.app\tpersistentApps\t/Users/me/Library/Preferences/com.apple.dock.plist\tcom.apple.Terminal\n"
+            "Downloads\tfile:///Users/me/Downloads/\tpersistentOthers\t/Users/me/Library/Preferences/com.apple.dock.plist\t\n"
+        )
+        self.assertEqual(
+            parse_dockutil_output(output),
+            [
+                {
+                    "name": "Terminal",
+                    "path": "/Applications/Terminal.app",
+                    "section": "apps",
+                    "plist": "/Users/me/Library/Preferences/com.apple.dock.plist",
+                },
+                {
+                    "name": "Downloads",
+                    "path": "/Users/me/Downloads",
+                    "section": "others",
+                    "plist": "/Users/me/Library/Preferences/com.apple.dock.plist",
+                },
+            ],
+        )
+        with self.assertRaisesRegex(ValueError, "line 1"):
+            parse_dockutil_output("not tab delimited")
+
+    def test_compares_order_and_only_requested_presentation(self):
+        current = [
+            {"path": "/Applications/A.app", "section": "apps", "options": {}},
+            {
+                "path": "/Users/me/Downloads",
+                "section": "others",
+                "options": {"view": "auto", "display": "stack", "sort": "dateadded"},
+            },
+        ]
+        desired = [
+            {"path": "/Applications/A.app", "section": "apps", "options": {}},
+            {
+                "path": "/Users/me/Downloads",
+                "section": "others",
+                "options": {"display": "stack"},
+            },
+        ]
+        self.assertTrue(dock_states_match(current, desired))
+        self.assertFalse(dock_states_match(list(reversed(current)), desired))
+
+    def test_generates_options_in_a_stable_order(self):
+        self.assertEqual(
+            dock_option_arguments({"sort": "dateadded", "display": "stack", "view": "auto"}),
+            ["--view", "auto", "--display", "stack", "--sort", "dateadded"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
+    json_safe_plist,


### PR DESCRIPTION
## Summary

- rewrite `macos_defaults_plist` with strict plist validation, deterministic dictionary merges, structured diffs, and post-write verification
- rewrite `dock_items` with typed presentation options, URL-safe normalization, preflight validation, post-change verification, and best-effort rollback
- extract shared pure-Python macOS helpers and add focused unit coverage
- migrate local callers from `dict_mode: add` to `merge` and raw dockutil arguments to typed fields
- run the module unit tests in the static validation workflow

## Notable behavior

- Dock reconciliation refuses to clear the Dock when a configured filesystem item is missing.
- Failed Dock rebuilds attempt to restore the captured previous state.
- Binary plist data is represented safely in Ansible results and diffs instead of violating strict UTF-8 response handling.
- Both four- and five-column `dockutil --list` formats are supported.

## Validation

- `mise exec -- prek run --all-files`
- `python3 -m unittest discover -s tests/unit -v` — 9 tests passed
- Ansible playbook syntax check
- local macOS `system_defaults` check-mode run — `ok=158 changed=0 failed=0`
- local macOS `system_defaults` normal run — `ok=158 changed=0 failed=0`
- final idempotency check — `ok=158 changed=0 failed=0`
