### PR TITLE
fix(docs): stabilize instant navigation links

### DIFF
--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -16,6 +16,22 @@
     }
   }
 
+  function normalizePersistentNavigationLinks() {
+    const links = document.querySelectorAll(
+      '[data-md-component="header"] a[href], .md-sidebar--primary a[href]',
+    );
+
+    links.forEach((link) => {
+      const href = link.getAttribute("href");
+      if (href === null || href.startsWith("#")) return;
+
+      const target = new URL(href, window.location.href);
+      if (target.origin !== window.location.origin) return;
+
+      link.setAttribute("href", `${target.pathname}${target.search}${target.hash}`);
+    });
+  }
+
   function setupPage() {
     pageController?.abort();
     pageController = new AbortController();
@@ -35,6 +51,7 @@
     const progress = document.querySelector("[data-reading-progress]");
 
     applyTheme(localStorage.getItem("om-theme") || "dark");
+    normalizePersistentNavigationLinks();
 
     const closeContextHelp = () => {
       if (!contextHelpDialog?.open) return;


### PR DESCRIPTION
## Summary

- normalize same-origin links in the persistent header and primary sidebar to stable root-relative URLs
- prevent the homepage link from resolving to the current page after a Zensical instant-navigation transition
- cover the same stale-relative-link behavior for the remaining persistent navigation links

## Root cause

Zensical renders the homepage link as an empty relative href on the homepage. Because instant navigation preserves the custom header, navigating to Setup leaves that href in place, where the browser resolves it against /setup/ instead of the site root.

## Validation

- clean strict Zensical build
- JavaScript syntax check
- generated asset parity check
- navigation URL transition regression check
- repository pre-commit hooks