### PR TITLE
fix(neovim): restore lock after fresh bootstrap

### DIFF
--- a/scripts/common/ansible/roles/neovim/tasks/main.yaml
+++ b/scripts/common/ansible/roles/neovim/tasks/main.yaml
@@ -10,3 +10,29 @@
       - --headless
       - +qa
     creates: "{{ ansible_facts['user_dir'] }}/.local/share/nvim/lazy/LazyVim"
+  register: lazyvim_bootstrap
+
+- name: "restore committed LazyVim lockfile after bootstrap"
+  ansible.builtin.command:
+    argv:
+      - chezmoi
+      - --source
+      - "{{ dotfiles.checkout }}/config"
+      - --working-tree
+      - "{{ dotfiles.checkout }}"
+      - apply
+      - --force
+      - "{{ ansible_facts['user_dir'] }}/.config/nvim/lazy-lock.json"
+  when: lazyvim_bootstrap is changed
+
+- name: "restore LazyVim plugins from committed lockfile"
+  ansible.builtin.command:
+    argv:
+      - mise
+      - exec
+      - --
+      - nvim
+      - --headless
+      - "+Lazy! restore"
+      - +qa
+  when: lazyvim_bootstrap is changed


### PR DESCRIPTION
## Summary

- keep the native LazyVim bootstrap
- after a fresh bootstrap only, reapply the committed `lazy-lock.json` through chezmoi
- restore the newly discovered plugins to their locked revisions

## Why

A clean LazyVim installation resolves plugin specifications incrementally. During that process, lazy.nvim can rewrite the lockfile before late-discovered plugins such as `SchemaStore.nvim` are installed. The targeted chezmoi apply restores both the committed file and chezmoi state; `Lazy restore` then checks out the pinned revisions. Normal subsequent runs do no reconciliation work.

## Validation

- fresh Docker provisioning completed successfully
- committed and installed lockfiles are byte-identical
- `chezmoi status` is empty after `Lazy restore` and a normal Neovim startup
- `SchemaStore.nvim` is at pinned commit `b4a92475bb6928810b66a0dd2fd86bea44089aba`
- second Ansible pass: `changed=0`, `unreachable=0`, `failed=0`
- `mise exec -- prek run --all-files`
- `/opt/homebrew/bin/python3.14 -m unittest discover -s tests/unit -v` (9 passed)