### PR TITLE
feat(docs): adopt Zensical built-ins and polish shortcuts

### DIFF
--- a/docs-overrides/main.html
+++ b/docs-overrides/main.html
@@ -1,11 +1,1 @@
 {% extends "base.html" %}
-
-{% block extrahead %}
-  <script>
-    (() => {
-      const theme = localStorage.getItem("om-theme") === "light" ? "light" : "dark";
-      document.documentElement.dataset.theme = theme;
-      document.documentElement.style.colorScheme = theme;
-    })();
-  </script>
-{% endblock %}

--- a/docs-overrides/partials/header.html
+++ b/docs-overrides/partials/header.html
@@ -24,10 +24,17 @@
     </nav>
 
     <div class="header-actions">
-      <button class="theme-toggle" type="button" aria-label="Switch to light color scheme" data-theme-toggle>light</button>
-      <a class="header-icon md-icon" href="https://github.com/shmileee/dotfiles" aria-label="View the dotfiles repository on GitHub">
-        {% include ".icons/fontawesome/brands/github.svg" %}
-      </a>
+      {% if config.theme.palette %}
+        {% if not config.theme.palette is mapping %}
+          {% include "partials/palette.html" %}
+          {% include "partials/javascripts/palette.html" %}
+        {% endif %}
+      {% endif %}
+      {% if config.repo_url %}
+        <a class="header-icon md-icon" href="{{ config.repo_url }}" aria-label="View {{ config.repo_name }} on GitHub">
+          {% include ".icons/fontawesome/brands/github.svg" %}
+        </a>
+      {% endif %}
       <button class="header-icon md-icon" type="button" aria-haspopup="dialog" aria-label="Search documentation" data-search-toggle>
         {% include ".icons/material/magnify.svg" %}
       </button>

--- a/docs-overrides/partials/nav.html
+++ b/docs-overrides/partials/nav.html
@@ -27,11 +27,13 @@
         <path d="M5 3h8v8M13 3 3 13" />
       </svg>
     </a>
-    <a class="external-nav-link" href="https://github.com/shmileee/dotfiles" aria-label="GitHub repository (external site)">
-      <span>GitHub</span>
-      <svg class="external-nav-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-        <path d="M5 3h8v8M13 3 3 13" />
-      </svg>
-    </a>
+    {% if config.repo_url %}
+      <a class="external-nav-link" href="{{ config.repo_url }}" aria-label="{{ config.repo_name }} on GitHub (external site)">
+        <span>GitHub</span>
+        <svg class="external-nav-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+          <path d="M5 3h8v8M13 3 3 13" />
+        </svg>
+      </a>
+    {% endif %}
   </nav>
 </nav>

--- a/docs-overrides/partials/progress.html
+++ b/docs-overrides/partials/progress.html
@@ -1,6 +1,5 @@
 <div
   class="md-progress"
   data-md-component="progress"
-  role="progressbar"
-  aria-label="Loading page"
+  aria-hidden="true"
 ></div>

--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -32,9 +32,80 @@
     const drawerToggle = document.querySelector("#__drawer");
     const primarySidebar = document.querySelector(".md-sidebar--primary");
     const drawerTocToggle = primarySidebar?.querySelector("#__toc");
+    const drawerTocLabels = [...(primarySidebar?.querySelectorAll('label[for="__toc"]') || [])];
     const progress = document.querySelector("[data-reading-progress]");
 
     normalizePersistentNavigationLinks();
+
+    document.querySelector(".md-overlay")?.setAttribute("aria-hidden", "true");
+    document.querySelectorAll(".md-code__nav").forEach((nav, index) => {
+      nav.setAttribute("aria-label", `Code block ${index + 1} actions`);
+    });
+
+    const enhanceInjectedSearch = () => {
+      const searchHost = [...document.querySelectorAll("body > div")]
+        .find((element) => element.shadowRoot?.querySelector('input[role="combobox"]'));
+      const searchRoot = searchHost?.shadowRoot;
+      const searchInput = searchRoot?.querySelector('input[role="combobox"]');
+      if (!searchHost || !searchRoot || !searchInput) return false;
+
+      const searchToolbar = searchInput.parentElement?.parentElement;
+      const searchButtons = [...(searchToolbar?.querySelectorAll("button") || [])];
+      const searchResults = searchRoot.querySelector("ol");
+      const filterHeading = [...searchRoot.querySelectorAll("h3")]
+        .find((heading) => heading.textContent.trim() === "Filters");
+      const filterPanel = filterHeading?.parentElement?.parentElement;
+      let searchPanel = searchToolbar;
+      while (searchPanel && !(searchPanel.contains(searchResults) && searchPanel.contains(filterPanel))) {
+        searchPanel = searchPanel.parentElement;
+      }
+
+      searchHost.setAttribute("role", "search");
+      searchHost.setAttribute("aria-label", "Site search");
+      searchInput.setAttribute("aria-label", "Search documentation");
+      searchInput.setAttribute("aria-autocomplete", "list");
+      if (searchResults) {
+        searchResults.id = "site-search-results";
+        searchResults.setAttribute("role", "listbox");
+        searchInput.setAttribute("aria-controls", searchResults.id);
+      }
+      if (searchButtons[0]) searchButtons[0].setAttribute("aria-label", "Search documentation");
+      if (searchButtons[1] && filterPanel) {
+        filterPanel.id = "site-search-filters";
+        filterPanel.setAttribute("role", "region");
+        filterPanel.setAttribute("aria-label", "Search filters");
+        searchButtons[1].setAttribute("aria-label", "Toggle search filters");
+        searchButtons[1].setAttribute("aria-controls", filterPanel.id);
+      }
+
+      const syncInjectedSearch = () => {
+        const searchIsOpen = searchPanel && getComputedStyle(searchPanel).pointerEvents !== "none";
+        searchInput.setAttribute("aria-expanded", String(Boolean(searchIsOpen)));
+        const filtersAreOpen = filterPanel && getComputedStyle(filterPanel).pointerEvents !== "none"
+          && filterPanel.getBoundingClientRect().width > 0;
+        if (filterPanel) {
+          filterPanel.setAttribute("aria-hidden", String(!filtersAreOpen));
+          filterPanel.tabIndex = filtersAreOpen ? 0 : -1;
+        }
+        searchButtons[1]?.setAttribute("aria-expanded", String(Boolean(filtersAreOpen)));
+      };
+      const injectedSearchObserver = new MutationObserver(syncInjectedSearch);
+      if (searchPanel) injectedSearchObserver.observe(searchPanel, { attributes: true, attributeFilter: ["class"] });
+      if (filterPanel) injectedSearchObserver.observe(filterPanel, { attributes: true, attributeFilter: ["class"] });
+      signal.addEventListener("abort", () => injectedSearchObserver.disconnect(), { once: true });
+      syncInjectedSearch();
+      return true;
+    };
+    if (!enhanceInjectedSearch()) {
+      let searchEnhancementAttempts = 0;
+      const searchEnhancementTimer = window.setInterval(() => {
+        searchEnhancementAttempts += 1;
+        if (enhanceInjectedSearch() || searchEnhancementAttempts >= 100) {
+          window.clearInterval(searchEnhancementTimer);
+        }
+      }, 50);
+      signal.addEventListener("abort", () => window.clearInterval(searchEnhancementTimer), { once: true });
+    }
 
     const closeContextHelp = () => {
       if (!contextHelpDialog?.open) return;
@@ -129,7 +200,20 @@
       const drawerIsOpen = Boolean(drawerToggle?.checked);
       drawerButton?.setAttribute("aria-expanded", String(drawerIsOpen));
       drawerButton?.setAttribute("aria-label", drawerIsOpen ? "Close navigation" : "Open navigation");
+      drawerTocLabels.forEach((label) => {
+        label.setAttribute("aria-expanded", String(Boolean(drawerTocToggle?.checked)));
+      });
     };
+
+    drawerTocLabels.forEach((label) => {
+      label.setAttribute("role", "button");
+      label.tabIndex = 0;
+      label.addEventListener("keydown", (event) => {
+        if (event.key !== " ") return;
+        event.preventDefault();
+        label.click();
+      }, { signal });
+    });
 
     const setTabbable = (elements, enabled) => {
       elements.forEach((element) => {
@@ -192,7 +276,10 @@
       { signal },
     );
 
-    drawerTocToggle?.addEventListener("change", syncDrawerFocus, { signal });
+    drawerTocToggle?.addEventListener("change", () => {
+      syncControls();
+      syncDrawerFocus();
+    }, { signal });
 
     document.addEventListener(
       "keydown",

--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -1,20 +1,5 @@
 (() => {
-  const root = document.documentElement;
   let pageController;
-
-  function applyTheme(theme) {
-    const normalized = theme === "light" ? "light" : "dark";
-    root.dataset.theme = normalized;
-    root.style.colorScheme = normalized;
-    document.body?.setAttribute("data-md-color-scheme", normalized === "light" ? "default" : "slate");
-
-    const button = document.querySelector("[data-theme-toggle]");
-    if (button) {
-      const next = normalized === "dark" ? "light" : "dark";
-      button.textContent = next;
-      button.setAttribute("aria-label", `Switch to ${next} color scheme`);
-    }
-  }
 
   function normalizePersistentNavigationLinks() {
     const links = document.querySelectorAll(
@@ -42,7 +27,6 @@
     if (contextHelpTrigger && contextHelpDialog) {
       document.body.append(contextHelpTrigger, contextHelpDialog);
     }
-    const themeButton = document.querySelector("[data-theme-toggle]");
     const searchButton = document.querySelector("[data-search-toggle]");
     const drawerButton = document.querySelector("[data-drawer-toggle]");
     const drawerToggle = document.querySelector("#__drawer");
@@ -50,7 +34,6 @@
     const drawerTocToggle = primarySidebar?.querySelector("#__toc");
     const progress = document.querySelector("[data-reading-progress]");
 
-    applyTheme(localStorage.getItem("om-theme") || "dark");
     normalizePersistentNavigationLinks();
 
     const closeContextHelp = () => {
@@ -243,30 +226,6 @@
     syncControls();
     syncDrawerFocus();
 
-    const syncShortcutRows = () => {
-      const rows = document.querySelectorAll(".shortcut-reference table:not(:has(th:nth-child(3))) tbody tr");
-      rows.forEach((row) => row.classList.remove("shortcut-row--stacked"));
-      if (window.innerWidth > 480) return;
-      rows.forEach((row) => {
-        const shortcut = row.querySelector("td:first-child");
-        if (shortcut && shortcut.scrollWidth > shortcut.clientWidth + 1) {
-          row.classList.add("shortcut-row--stacked");
-        }
-      });
-    };
-
-    let shortcutResizeScheduled = false;
-    const scheduleShortcutRows = () => {
-      if (shortcutResizeScheduled) return;
-      shortcutResizeScheduled = true;
-      requestAnimationFrame(() => {
-        syncShortcutRows();
-        shortcutResizeScheduled = false;
-      });
-    };
-    window.addEventListener("resize", scheduleShortcutRows, { signal });
-    syncShortcutRows();
-
     const shortcutFilter = document.querySelector("[data-shortcut-filter]");
     const shortcutQuery = shortcutFilter?.querySelector("[data-shortcut-query]");
     const shortcutClear = shortcutFilter?.querySelector("[data-shortcut-clear]");
@@ -347,7 +306,6 @@
       shortcutEmpty.hidden = visibleCount !== 0;
       shortcutStatus.textContent = `Showing ${visibleCount} of ${shortcutRows.length} shortcuts`;
       syncShortcutToc();
-      syncShortcutRows();
       syncDrawerFocus();
     };
 
@@ -375,16 +333,6 @@
       });
       syncShortcutFilter();
     }
-
-    themeButton?.addEventListener(
-      "click",
-      () => {
-        const theme = root.dataset.theme === "dark" ? "light" : "dark";
-        localStorage.setItem("om-theme", theme);
-        applyTheme(theme);
-      },
-      { signal },
-    );
 
     if (!progress) return;
 

--- a/docs/assets/stylesheets/design-system.css
+++ b/docs/assets/stylesheets/design-system.css
@@ -103,7 +103,7 @@
   --md-code-font: "IBM Plex Mono", ui-monospace, monospace;
 }
 
-:root[data-theme="light"] {
+body[data-md-color-scheme="default"] {
   color-scheme: light;
   --surface-primary: #f4f5f7;
   --surface-secondary: #ffffff;

--- a/docs/assets/stylesheets/design-system.css
+++ b/docs/assets/stylesheets/design-system.css
@@ -65,6 +65,7 @@
   --border-strong: rgba(255, 255, 255, 0.28);
   --accent-primary: #60a5fa;
   --accent-soft: #93c5fd;
+  --inline-code-text: #93c5fd;
   --accent-surface: rgba(37, 99, 235, 0.14);
   --selection-surface: rgba(96, 165, 250, 0.12);
   --accent-border: rgba(96, 165, 250, 0.35);
@@ -117,6 +118,7 @@ body[data-md-color-scheme="default"] {
   --border-strong: rgba(17, 24, 39, 0.28);
   --accent-primary: #1d4ed8;
   --accent-soft: #1d4ed8;
+  --inline-code-text: #1e3a8a;
   --accent-surface: rgba(37, 99, 235, 0.14);
   --selection-surface: rgba(37, 99, 235, 0.1);
   --accent-border: rgba(37, 99, 235, 0.4);

--- a/docs/assets/stylesheets/mkdocs.css
+++ b/docs/assets/stylesheets/mkdocs.css
@@ -403,7 +403,7 @@ button.header-icon {
   border-radius: 0.25rem;
   padding: 0.08em 0.32em;
   background: var(--accent-surface);
-  color: var(--accent-soft);
+  color: var(--inline-code-text);
   box-decoration-break: clone;
   font-size: 0.82em;
   font-weight: 500;
@@ -2033,6 +2033,7 @@ body:has(.context-help[open]) .context-help-trigger {
   .mobile-page-toc__label small {
     color: var(--text-tertiary);
     font: 500 0.6875rem/1.4 "IBM Plex Mono", ui-monospace, monospace;
+    opacity: 1;
   }
 
   .md-typeset .mobile-page-toc > summary::before,
@@ -2283,6 +2284,10 @@ body:has(.context-help[open]) .context-help-trigger {
 
   .shortcut-filter__scopes button {
     min-height: 2.75rem;
+  }
+
+  .md-typeset .tabbed-labels {
+    width: calc(100% + 1.6rem);
   }
 
   .shortcut-reference table thead {

--- a/docs/assets/stylesheets/mkdocs.css
+++ b/docs/assets/stylesheets/mkdocs.css
@@ -49,6 +49,12 @@ body[data-md-color-scheme] {
   color: var(--text-body);
   box-shadow: none;
   backdrop-filter: blur(12px);
+  transition: transform 250ms cubic-bezier(0.8, 0, 0.6, 1);
+}
+
+.site-header[hidden] {
+  display: block;
+  transform: translateY(-100%);
 }
 
 .reading-progress {
@@ -86,7 +92,6 @@ body[data-md-color-scheme] {
 .brand-link,
 .docs-home,
 .site-nav a,
-.theme-toggle,
 .header-icon,
 .docs-adjacent,
 .section-eyebrow,
@@ -165,8 +170,7 @@ body[data-md-color-scheme] {
   margin-left: auto;
 }
 
-.site-nav a,
-.theme-toggle {
+.site-nav a {
   min-height: 2.5rem;
   display: inline-flex;
   align-items: center;
@@ -199,8 +203,7 @@ body[data-md-color-scheme] {
 }
 
 .site-nav a:hover,
-.site-nav a.is-active,
-.theme-toggle:hover {
+.site-nav a.is-active {
   color: var(--text-primary);
 }
 
@@ -223,14 +226,33 @@ body[data-md-color-scheme] {
   gap: var(--space-2);
 }
 
-.theme-toggle {
-  min-height: 2.75rem;
-  min-width: 4.25rem;
-  border: 1px solid var(--border-default);
-  border-radius: 999px;
-  padding: 0.3125rem 0.75rem;
-  background: transparent;
-  cursor: pointer;
+.header-actions .md-header__option {
+  margin: 0;
+}
+
+.header-actions .md-header__option .md-header__button {
+  width: 2.75rem;
+  height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  margin: 0;
+  border-radius: 50%;
+  padding: 0;
+  color: var(--text-secondary);
+}
+
+.header-actions .md-header__option .md-header__button:not([hidden]) {
+  display: inline-flex;
+}
+
+.header-actions .md-header__option .md-header__button:hover {
+  color: var(--text-primary);
+  opacity: 1;
+}
+
+.header-actions .md-header__option svg {
+  width: 1.15rem;
+  fill: currentcolor;
 }
 
 .header-icon {
@@ -1272,12 +1294,16 @@ body:has(.context-help[open]) .context-help-trigger {
 }
 
 .shortcut-reference .md-typeset__scrollwrap {
-  margin: var(--space-3) 0 var(--space-8);
+  margin: var(--space-4) 0 var(--space-8);
 }
 
 .shortcut-reference .md-typeset__table {
   width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border-default);
+  border-radius: 0.625rem;
   padding: 0;
+  background: var(--surface-secondary);
 }
 
 .md-typeset .shortcut-reference table:not([class]) {
@@ -1296,54 +1322,117 @@ body:has(.context-help[open]) .context-help-trigger {
 
 .shortcut-reference table tr {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(13.5rem, 0.8fr) minmax(0, 1.2fr);
 }
 
 .shortcut-reference table:has(th:nth-child(3)) tr {
-  grid-template-columns: 5rem minmax(9rem, 0.75fr) minmax(0, 1.25fr);
+  grid-template-columns: 6.5rem minmax(12rem, 0.8fr) minmax(0, 1.2fr);
 }
 
 .shortcut-reference table thead tr {
-  border-bottom: 1px solid var(--border-subtle);
+  background: var(--code-toolbar);
 }
 
 .shortcut-reference table tbody tr {
-  margin-top: var(--space-2);
-  border: 1px solid var(--border-default);
-  border-radius: 0.5rem;
+  min-height: 3.75rem;
+  border-top: 1px solid var(--border-subtle);
   background: var(--surface-secondary);
-  transition: border-color 130ms ease-out, background-color 130ms ease-out;
+  transition: background-color 130ms ease-out;
 }
 
 .shortcut-reference table tbody tr:hover {
-  border-color: var(--accent-border);
   background: color-mix(in srgb, var(--surface-secondary) 88%, var(--accent-primary));
+}
+
+.shortcut-reference table tbody td {
+  transition: background-color 130ms ease-out;
+}
+
+.shortcut-reference table tbody tr:hover td {
+  background-color: color-mix(in srgb, var(--surface-secondary) 90%, var(--accent-primary));
+}
+
+.shortcut-reference table:not(:has(th:nth-child(3))) tbody tr:hover td:first-child,
+.shortcut-reference table:has(th:nth-child(3)) tbody tr:hover td:nth-child(2) {
+  background-color: color-mix(in srgb, var(--code-toolbar) 82%, var(--accent-primary));
 }
 
 .md-typeset .shortcut-reference table th,
 .md-typeset .shortcut-reference table td {
   min-width: 0;
   border: 0;
-  padding: var(--space-3) var(--space-4);
+  padding: 0.875rem var(--space-4);
+  text-align: center;
   vertical-align: middle;
 }
 
 .md-typeset .shortcut-reference table th {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   color: var(--text-tertiary);
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 0.6875rem;
+  font-weight: 600;
   letter-spacing: 0.1em;
   text-transform: uppercase;
+}
+
+.md-typeset .shortcut-reference table td {
+  display: block;
+  align-content: center;
+}
+
+.md-typeset .shortcut-reference table:not([class]) td:not([align]) {
+  text-align: center;
+}
+
+.md-typeset .shortcut-reference table th + th {
+  border-left: 1px solid var(--border-subtle);
+}
+
+.md-typeset .shortcut-reference table:not([class]) td:last-child:not([align]) {
+  overflow-wrap: break-word;
+  line-height: 1.6;
+  text-align: left;
+  text-wrap: pretty;
+}
+
+.md-typeset .shortcut-reference table td:last-child a code {
+  border-color: var(--border-default);
+  background: var(--code-toolbar);
+  color: var(--accent-soft);
+}
+
+.md-typeset .shortcut-reference table td:last-child a:hover code {
+  border-color: var(--accent-border);
+  background: var(--accent-surface);
 }
 
 .shortcut-reference table:has(th:nth-child(3)) td:nth-child(2) {
   white-space: nowrap;
 }
 
-.shortcut-reference table td:first-child {
+.shortcut-reference table:has(th:nth-child(3)) th:first-child,
+.shortcut-reference table:has(th:nth-child(3)) td:first-child {
+  overflow-wrap: normal;
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.shortcut-reference table:not(:has(th:nth-child(3))) td:first-child,
+.shortcut-reference table:has(th:nth-child(3)) td:nth-child(2) {
   background: var(--code-toolbar);
   color: var(--text-primary);
   font-family: "IBM Plex Mono", ui-monospace, monospace;
+}
+
+.shortcut-reference table:has(th:nth-child(3)) td:first-child {
+  color: var(--text-tertiary);
+  font: 600 0.6875rem/1.4 "IBM Plex Mono", ui-monospace, monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .shortcut-reference table td + td {
@@ -1354,20 +1443,35 @@ body:has(.context-help[open]) .context-help-trigger {
   white-space: nowrap;
 }
 
+.shortcut-reference table .shortcut-then {
+  display: inline-block;
+  margin-inline: 0.45rem;
+  color: var(--text-tertiary);
+  font-size: 0.75rem;
+}
+
 .md-typeset .shortcut-reference table .keys kbd {
-  padding: 0.125rem 0.45rem;
+  min-width: 1.75rem;
+  border-radius: 0.3rem;
+  padding: 0.1875rem 0.5rem;
   font-size: 0.75rem;
   line-height: 1.5;
 }
 
 .md-typeset .shortcut-reference table td:first-child code,
 .md-typeset .shortcut-reference table:has(th:nth-child(3)) td:nth-child(2) code {
+  min-width: 1.75rem;
+  display: inline-block;
   border-color: var(--border-default);
-  padding: 0.125rem 0.4rem;
+  border-radius: 0.3rem;
+  padding: 0.1875rem 0.5rem;
   background: var(--surface-primary);
   color: var(--text-primary);
+  box-shadow: 0 0.1rem 0 var(--border-default);
   font-size: 0.75rem;
   line-height: 1.5;
+  text-align: center;
+  vertical-align: text-top;
 }
 
 .md-typeset .tabbed-labels {
@@ -2095,12 +2199,6 @@ body:has(.context-help[open]) .context-help-trigger {
     display: inline;
   }
 
-  .theme-toggle {
-    min-height: 2.75rem;
-    min-width: 3.5rem;
-    padding-inline: var(--space-2);
-  }
-
   .header-icon {
     width: 2.75rem;
     height: 2.75rem;
@@ -2201,26 +2299,34 @@ body:has(.context-help[open]) .context-help-trigger {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .md-typeset .shortcut-reference table td {
-    padding: 0.625rem 0.875rem;
+  .shortcut-reference table:not(:has(th:nth-child(3))) tr {
+    grid-template-columns: minmax(0, 1fr);
   }
 
+  .shortcut-reference table tbody tr + tr {
+    border-top: 2px solid var(--border-default);
+  }
+
+  .md-typeset .shortcut-reference table td {
+    padding: 0.75rem var(--space-4);
+  }
+
+  .shortcut-reference table td + td,
   .shortcut-reference table:has(th:nth-child(3)) td + td {
     border-top: 1px solid var(--border-subtle);
     border-left: 0;
   }
 
+  .shortcut-reference table:not(:has(th:nth-child(3))) td:first-child {
+    min-height: 3.25rem;
+  }
+
   .shortcut-reference table:has(th:nth-child(3)) td:first-child {
-    padding-bottom: 0;
-    color: var(--text-tertiary);
-    font-size: 0.6875rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    padding-block: 0.5rem;
   }
 
   .shortcut-reference table:has(th:nth-child(3)) td:nth-child(2) {
-    border-top: 0;
-    background: var(--code-toolbar);
+    min-height: 3.25rem;
   }
 
   .setup-reference .md-typeset__scrollwrap,
@@ -2304,15 +2410,6 @@ body:has(.context-help[open]) .context-help-trigger {
     gap: var(--space-2);
   }
 
-  .shortcut-reference table:not(:has(th:nth-child(3))) tr.shortcut-row--stacked {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .shortcut-reference table:not(:has(th:nth-child(3))) tr.shortcut-row--stacked td + td {
-    border-top: 1px solid var(--border-subtle);
-    border-left: 0;
-  }
-
   .md-content__inner {
     padding-top: var(--space-12);
   }
@@ -2348,16 +2445,5 @@ body:has(.context-help[open]) .context-help-trigger {
 
   .header-actions > a[href*="github.com"] {
     display: none;
-  }
-}
-
-@media (max-width: 400px) {
-  .shortcut-reference table:not(:has(th:nth-child(3))) tr {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .shortcut-reference table:not(:has(th:nth-child(3))) td + td {
-    border-top: 1px solid var(--border-subtle);
-    border-left: 0;
   }
 }

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -68,7 +68,7 @@ and the files under
 
 ### Platform requirements
 
-=== "Apple Silicon macOS"
+=== "macOS"
 
     Install available system updates and the Xcode Command Line Tools on a
     fresh machine:
@@ -78,7 +78,7 @@ and the files under
     xcode-select --install
     ```
 
-=== "Ubuntu 24.04 ARM64"
+=== "Ubuntu"
 
     Use an account with `sudo` access. The bootstrap installs the apt
     prerequisites, adds the Ansible PPA, and then installs Homebrew.

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -127,42 +127,42 @@ Press ++ctrl+a++, release it, and then press the command key.
 
 | Command | Action |
 | --- | --- |
-| ++ctrl+a++ then `c` | Create a window in the current directory |
-| ++ctrl+a++ then `r` | Rename the current window |
-| ++ctrl+a++ then `R` | Rename the current session |
-| ++ctrl+a++ then `\|` | Split the pane horizontally |
-| ++ctrl+a++ then `_` | Split the pane vertically |
-| ++ctrl+a++ then `+` | Toggle pane zoom |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `c` | Create a window in the current directory |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `r` | Rename the current window |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `R` | Rename the current session |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `\|` | Split the pane horizontally |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `_` | Split the pane vertically |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `+` | Toggle pane zoom |
 
 ### Move around
 
 | Command | Action |
 | --- | --- |
-| ++ctrl+a++ then `h` / `j` / `k` / `l` | Move one pane left, down, up, or right |
-| ++ctrl+a++ then `[` / `]` | Select the previous / next pane |
-| ++ctrl+a++ then `{` / `}` | Select the previous / next window |
-| ++ctrl+a++ then ++tab++ | Return to the most recently used window |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `h` / `j` / `k` / `l` | Move one pane left, down, up, or right |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `[` / `]` | Select the previous / next pane |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `{` / `}` | Select the previous / next window |
+| ++ctrl+a++ <span class="shortcut-then">then</span> ++tab++ | Return to the most recently used window |
 
 ### Close and detach
 
 | Command | Action |
 | --- | --- |
-| ++ctrl+a++ then `x` | Kill the current pane |
-| ++ctrl+a++ then `X` | Kill the current window |
-| ++ctrl+a++ then ++ctrl+x++ | Confirm and kill every other window |
-| ++ctrl+a++ then `Q` | Confirm and kill the session |
-| ++ctrl+a++ then `d` | Detach this client |
-| ++ctrl+a++ then `D` | Detach other clients when present |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `x` | Kill the current pane |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `X` | Kill the current window |
+| ++ctrl+a++ <span class="shortcut-then">then</span> ++ctrl+x++ | Confirm and kill every other window |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `Q` | Confirm and kill the session |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `d` | Detach this client |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `D` | Detach other clients when present |
 
 ### Configuration and copy mode
 
 | Command | Action |
 | --- | --- |
-| ++ctrl+a++ then ++ctrl+e++ | Edit [`tmux.conf`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf), then reload it |
-| ++ctrl+a++ then ++ctrl+r++ | Reload [`tmux.conf`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf) |
+| ++ctrl+a++ <span class="shortcut-then">then</span> ++ctrl+e++ | Edit [`tmux.conf`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf), then reload it |
+| ++ctrl+a++ <span class="shortcut-then">then</span> ++ctrl+r++ | Reload [`tmux.conf`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf) |
 | ++ctrl+s++ | Enter copy mode without the prefix |
-| ++ctrl+a++ then `p` | Paste the latest tmux buffer |
-| ++ctrl+a++ then ++ctrl+p++ | Choose a tmux buffer |
+| ++ctrl+a++ <span class="shortcut-then">then</span> `p` | Paste the latest tmux buffer |
+| ++ctrl+a++ <span class="shortcut-then">then</span> ++ctrl+p++ | Choose a tmux buffer |
 
 Copy mode uses vi keys and supports the mouse wheel, Page Up and Page Down, and
 Option-based scrolling by line or half page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ site_dir: site
 site_name: dotfiles
 site_description: Reproducible workstation setup and the reasoning behind it.
 site_url: https://dotfiles.oponomarov.com
+repo_url: https://github.com/shmileee/dotfiles
+repo_name: shmileee/dotfiles
+edit_uri: edit/master/docs/
 copyright: Copyright &copy; 2021&ndash;2026 Oleksandr Ponomarov
 
 nav:
@@ -17,16 +20,32 @@ theme:
   variant: classic
   custom_dir: docs-overrides
   palette:
-    scheme: slate
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: lucide/sun-moon
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: lucide/sun
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: lucide/moon
+        name: Switch to system preference
   language: en
   font: false
   favicon: assets/favicon.svg
   icon:
     repo: fontawesome/brands/github
   features:
+    - header.autohide
     - navigation.instant
     - search.highlight
     - navigation.expand
+    - content.action.view
+    - content.action.edit
     - content.code.copy
     - navigation.footer
     - navigation.instant.progress


### PR DESCRIPTION
## Summary

- enable repository view/edit actions, automatic color mode, header autohide, instant navigation, and related Zensical features
- redesign and normalize shortcut tables, key sequences, action cells, and responsive filtering
- improve mobile navigation, search, code controls, contrast, and accessibility behavior
- fix narrow-screen setup tabs and mobile table/TOC presentation

## Verification

- `mise run docs:build`
- `node --check docs/assets/javascripts/site-shell.js`
- `mise exec -- prek run --all-files`
- headless Chromium interaction checks for search, filters, tabs, copying, dialogs, drawer, mobile TOC, history, and back-to-top
- layout/runtime matrix across all four pages at 1440, 768, 390, and 320 px in light and dark modes