### PR TITLE
fix(provisioning): harden downloads and Dock reconciliation

### DIFF
--- a/scripts/common/ansible/library/dock_items.py
+++ b/scripts/common/ansible/library/dock_items.py
@@ -92,7 +92,7 @@ from urllib.parse import urlsplit
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.dotfiles_macos import (
-    dock_option_arguments,
+    dock_rebuild_commands,
     dock_states_match,
     normalize_location,
     parse_dockutil_output,
@@ -231,21 +231,11 @@ def desired_items(module: AnsibleModule) -> List[Dict[str, Any]]:
     return desired
 
 
-def add_arguments(dockutil: str, item: Mapping[str, Any]) -> List[str]:
-    argv = [dockutil, "--add", item["path"], "--position", "end"]
-    if item["section"] != "apps":
-        argv.extend(["--section", item["section"]])
-    argv.extend(dock_option_arguments(item.get("options", {})))
-    argv.append("--no-restart")
-    return argv
-
-
 def rebuild(
     module: AnsibleModule, dockutil: str, items: List[Mapping[str, Any]]
 ) -> None:
-    run_dockutil(module, [dockutil, "--remove", "all", "--no-restart"])
-    for item in items:
-        run_dockutil(module, add_arguments(dockutil, item))
+    for arguments in dock_rebuild_commands(dockutil, items):
+        run_dockutil(module, arguments)
 
 
 def restore(

--- a/scripts/common/ansible/module_utils/dotfiles_macos.py
+++ b/scripts/common/ansible/module_utils/dotfiles_macos.py
@@ -181,3 +181,26 @@ def dock_option_arguments(options: Mapping[str, str]) -> List[str]:
         if value is not None:
             arguments.extend(["--{0}".format(name), value])
     return arguments
+
+
+def dock_rebuild_commands(
+    dockutil: str, items: Iterable[Mapping[str, Any]]
+) -> List[List[str]]:
+    """Batch Dock mutations and let only the final command restart Dock."""
+    item_list = list(items)
+    remove_arguments = [dockutil, "--remove", "all"]
+    if item_list:
+        remove_arguments.append("--no-restart")
+    commands = [remove_arguments]
+
+    last_index = len(item_list) - 1
+    for index, item in enumerate(item_list):
+        arguments = [dockutil, "--add", item["path"], "--position", "end"]
+        if item["section"] != "apps":
+            arguments.extend(["--section", item["section"]])
+        arguments.extend(dock_option_arguments(item.get("options", {})))
+        if index != last_index:
+            arguments.append("--no-restart")
+        commands.append(arguments)
+
+    return commands

--- a/scripts/common/ansible/roles/mise/tasks/install.yaml
+++ b/scripts/common/ansible/roles/mise/tasks/install.yaml
@@ -6,5 +6,6 @@
     chdir: "{{ ansible_facts['user_dir'] }}"
   environment:
     GITHUB_TOKEN: "{{ lookup('ansible.builtin.env', 'GITHUB_TOKEN') }}"
+    MISE_HTTP_TIMEOUT: 120s
   register: mise_install
   changed_when: "'all tools are installed' not in (mise_install.stdout + mise_install.stderr)"

--- a/scripts/common/ansible/roles/system_defaults/handlers/main.yaml
+++ b/scripts/common/ansible/roles/system_defaults/handlers/main.yaml
@@ -15,11 +15,3 @@
       - cfprefsd
   register: restart_preference_services
   failed_when: restart_preference_services.rc not in [0, 1]
-
-- name: "restart dock"
-  ansible.builtin.command:
-    argv:
-      - /usr/bin/killall
-      - Dock
-  register: restart_dock
-  failed_when: restart_dock.rc not in [0, 1]

--- a/scripts/common/ansible/roles/system_defaults/tasks/dock.yaml
+++ b/scripts/common/ansible/roles/system_defaults/tasks/dock.yaml
@@ -3,4 +3,3 @@
 - name: "dockutil | reconcile configured items"
   dock_items:
     items: "{{ dockitems }}"
-  notify: restart dock

--- a/tests/unit/test_dotfiles_macos.py
+++ b/tests/unit/test_dotfiles_macos.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(ANSIBLE_DIR / "module_utils"))
 
 from dotfiles_macos import (  # noqa: E402
     dock_option_arguments,
+    dock_rebuild_commands,
     dock_states_match,
     json_safe_plist,
     merged_mapping,
@@ -128,6 +129,45 @@ class DockHelpersTest(unittest.TestCase):
                 {"sort": "dateadded", "display": "stack", "view": "auto"}
             ),
             ["--view", "auto", "--display", "stack", "--sort", "dateadded"],
+        )
+
+    def test_restarts_dock_only_after_the_final_batched_mutation(self):
+        items = [
+            {"path": "/Applications/A.app", "section": "apps", "options": {}},
+            {
+                "path": "/Users/me/Downloads",
+                "section": "others",
+                "options": {"display": "stack"},
+            },
+        ]
+        self.assertEqual(
+            dock_rebuild_commands("dockutil", items),
+            [
+                ["dockutil", "--remove", "all", "--no-restart"],
+                [
+                    "dockutil",
+                    "--add",
+                    "/Applications/A.app",
+                    "--position",
+                    "end",
+                    "--no-restart",
+                ],
+                [
+                    "dockutil",
+                    "--add",
+                    "/Users/me/Downloads",
+                    "--position",
+                    "end",
+                    "--section",
+                    "others",
+                    "--display",
+                    "stack",
+                ],
+            ],
+        )
+        self.assertEqual(
+            dock_rebuild_commands("dockutil", []),
+            [["dockutil", "--remove", "all"]],
         )
 
 


### PR DESCRIPTION
## Summary

This extracts two provisioning reliability fixes from #84 into an independent PR based directly on `master`:

- tolerate slow tool-download mirrors during `mise install`; and
- verify macOS Dock reconciliation after Dock has actually restarted.

Neither fix depends on the unified bootstrap rewrite.

## Why these changes are needed

### Slow tool mirrors

The ARM64 provisioning integration reached the normal Ansible `mise install` task, but Maven's `archive.apache.org` download exceeded mise's default 30-second HTTP timeout on all three attempts. The workstation setup then failed despite having no dependency-resolution or bootstrap error.

The mise role now sets `MISE_HTTP_TIMEOUT=120s`. Mise retains its own retry behavior, while slow but functioning mirrors have enough time to respond.

Consequence: a genuinely unreachable mirror takes longer to fail, but transiently slow mirrors are much less likely to abort a full workstation installation.

### Dock post-restart state

The macOS integration's first Ansible run succeeded, but its second run reported the Dock task and restart handler as changed again.

The custom module previously performed every mutation with `dockutil --no-restart`, inspected the on-disk plist, and deferred the Dock restart to an Ansible handler. That proved only the pre-restart plist state. The live Dock process could rewrite the plist during the later restart, making the following Ansible run rebuild it again.

The module now follows dockutil's documented batching behavior:

1. remove and add intermediate items with `--no-restart`;
2. let the final mutation invoke dockutil's own restart mechanism; and
3. inspect and verify the state after that final operation returns.

The redundant Ansible Dock restart handler is removed. Empty desired Dock configurations still restart after the removal operation.

Consequence: the task's success now means the live, post-restart Dock state matches the declaration. A failed post-restart comparison triggers the module's existing rollback/error path rather than producing a false successful result.

## Tests

- all repository `prek` hooks pass
- 10 Python unit tests pass, including the new batching/restart-order coverage
- Ansible syntax check passes
- the isolated PR's ARM64 Docker build, smoke test, and second provisioning pass pass
- the isolated PR's macOS provisioning, repository validation, and second idempotence pass pass

## Relationship to #84

#84 now contains only the bootstrap architecture rewrite. This PR can be reviewed and merged independently; #84's integration workflows may continue to expose these existing reliability issues until this PR is merged into `master` and #84 is rebased.
