### PR TITLE
fix(docs): improve mobile shortcut layout

### DIFF
--- a/docs/assets/javascripts/site-shell.js
+++ b/docs/assets/javascripts/site-shell.js
@@ -540,6 +540,32 @@
           if (!row.hidden) visibleCount += 1;
         });
 
+        rows.forEach((row) => {
+          row.classList.remove('is-shortcut-mode-start');
+          row.cells[0]?.removeAttribute('data-shortcut-mode-count');
+        });
+
+        if (section.dataset.shortcutSection === 'neovim') {
+          const visibleModes = new Map();
+          rows
+            .filter((row) => !row.hidden)
+            .forEach((row) => {
+              const mode = row.querySelector('.shortcut-mode')?.textContent;
+              if (!mode) return;
+              const modeRows = visibleModes.get(mode) ?? [];
+              modeRows.push(row);
+              visibleModes.set(mode, modeRows);
+            });
+
+          visibleModes.forEach((modeRows) => {
+            const modeCell = modeRows[0].cells[0];
+            modeRows[0].classList.add('is-shortcut-mode-start');
+            modeCell.dataset.shortcutModeCount = `${modeRows.length} shortcut${
+              modeRows.length === 1 ? '' : 's'
+            }`;
+          });
+        }
+
         section
           .querySelectorAll('.md-typeset__scrollwrap')
           .forEach((tableWrap) => {

--- a/docs/assets/stylesheets/mkdocs.css
+++ b/docs/assets/stylesheets/mkdocs.css
@@ -1557,6 +1557,10 @@ body:has(.mobile-page-toc[open]) .context-help-trigger {
   font-size: 0.75rem;
 }
 
+.shortcut-prefix-summary {
+  display: none;
+}
+
 .md-typeset .shortcut-reference table .keys kbd {
   min-width: 1.75rem;
   border-radius: 0.3rem;
@@ -2521,28 +2525,166 @@ body:has(.mobile-page-toc[open]) .context-help-trigger {
 
   .shortcut-reference[data-shortcut-section="tmux"]
     table:not(:has(th:nth-child(3)))
+    tbody {
+    display: grid;
+    grid-template-columns: minmax(5.5rem, max-content) minmax(0, 1fr);
+  }
+
+  .shortcut-reference[data-shortcut-section="tmux"]
+    table:not(:has(th:nth-child(3)))
     tbody
     tr {
-    grid-template-columns: minmax(0, 1fr);
-    padding: var(--space-3);
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+    padding: 0;
   }
 
   .md-typeset
     .shortcut-reference[data-shortcut-section="tmux"]
     table:not([class])
     td:not([align]) {
-    min-height: 0;
+    min-height: 3.5rem;
     border: 0;
-    padding: 0;
-    background: transparent;
+    padding: 0.625rem var(--space-3);
     text-align: left;
   }
 
   .md-typeset
     .shortcut-reference[data-shortcut-section="tmux"]
     table:not([class])
+    td:first-child:not([align]) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--code-toolbar);
+  }
+
+  .md-typeset
+    .shortcut-reference[data-shortcut-section="tmux"]
+    table:not([class])
     td:last-child:not([align]) {
-    margin-top: var(--space-2);
+    margin-top: 0;
+    border-left: 1px solid var(--border-subtle);
+  }
+
+  .shortcut-reference[data-shortcut-section="tmux"]
+    table
+    td:first-child
+    .keys:has(+ .shortcut-then),
+  .shortcut-reference[data-shortcut-section="tmux"]
+    table
+    td:first-child
+    .shortcut-then {
+    display: none;
+  }
+
+  .shortcut-prefix-summary {
+    display: flex;
+    min-height: 3rem;
+    align-items: center;
+    gap: var(--space-2);
+    margin: var(--space-5) 0 var(--space-6);
+    border-left: 0.1875rem solid var(--accent-primary);
+    border-radius: 0.5rem;
+    padding: var(--space-2) var(--space-3);
+    background: var(--accent-surface);
+  }
+
+  .shortcut-prefix-summary__label {
+    color: var(--accent-soft);
+    font:
+      600 0.75rem / 1.4 "IBM Plex Mono",
+      ui-monospace,
+      monospace;
+    text-transform: uppercase;
+  }
+
+  .shortcut-prefix-summary__release {
+    margin-left: auto;
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    tbody {
+    display: grid;
+    grid-template-columns: 7.5rem minmax(0, 1fr);
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    tbody
+    tr {
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    td:first-child {
+    display: none;
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    tr:has(.shortcut-mode--start)
+    td:first-child,
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    tr.is-shortcut-mode-start
+    td:first-child {
+    display: flex;
+    grid-column: 1 / -1;
+    align-items: center;
+    justify-content: space-between;
+    margin: 0;
+    border: 0;
+    border-bottom: 1px solid var(--border-subtle);
+    border-radius: 0;
+    padding: 0.625rem var(--space-3);
+    background: transparent;
+    color: var(--accent-soft);
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    tr.is-shortcut-mode-start
+    td:first-child::after {
+    content: attr(data-shortcut-mode-count);
+    color: var(--text-tertiary);
+    font:
+      400 0.75rem / 1.4 "IBM Plex Mono",
+      ui-monospace,
+      monospace;
+    letter-spacing: normal;
+    text-transform: none;
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    tr:has(.shortcut-mode--start)
+    .shortcut-mode::after,
+  .shortcut-reference[data-shortcut-section="neovim"]
+    tr.is-shortcut-mode-start
+    .shortcut-mode::after {
+    content: " mode";
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    td:nth-child(2) {
+    min-height: 3.5rem;
+    border: 0;
+    padding: 0.625rem var(--space-3);
+  }
+
+  .shortcut-reference[data-shortcut-section="neovim"]
+    table:has(th:nth-child(3))
+    td:last-child {
+    grid-column: auto;
+    border-top: 0;
+    border-left: 1px solid var(--border-subtle);
+    padding: 0.625rem var(--space-3);
   }
 
   .md-typeset .shortcut-reference[data-shortcut-section="tmux"] table .keys kbd,

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -123,6 +123,12 @@ source file for the exact mappings used by this configuration.
 
 Press ++ctrl+a++, release it, and then press the command key.
 
+<div class="shortcut-prefix-summary" aria-label="Prefix: Control plus A, then release" data-search-exclude>
+  <span class="shortcut-prefix-summary__label">Prefix</span>
+  <span class="keys"><kbd>Ctrl</kbd><span>+</span><kbd>A</kbd></span>
+  <span class="shortcut-prefix-summary__release">then release</span>
+</div>
+
 ### Create and arrange
 
 | Command | Action |
@@ -130,7 +136,7 @@ Press ++ctrl+a++, release it, and then press the command key.
 | ++ctrl+a++ <span class="shortcut-then">then</span> `c` | Create a window in the current directory |
 | ++ctrl+a++ <span class="shortcut-then">then</span> `r` | Rename the current window |
 | ++ctrl+a++ <span class="shortcut-then">then</span> `R` | Rename the current session |
-| ++ctrl+a++ <span class="shortcut-then">then</span> `\|` | Split the pane horizontally |
+| ++ctrl+a++ <span class="shortcut-then">then</span> <code>&#124;</code> | Split the pane horizontally |
 | ++ctrl+a++ <span class="shortcut-then">then</span> `_` | Split the pane vertically |
 | ++ctrl+a++ <span class="shortcut-then">then</span> `+` | Toggle pane zoom |
 
@@ -177,10 +183,10 @@ LazyVim provides most editor mappings. This repository adds only a small set:
 
 | Mode | Shortcut | Action |
 | --- | --- | --- |
-| Normal | `o` | Create a blank line below without staying in Insert mode |
-| Normal | `O` | Create a blank line above without staying in Insert mode |
-| Normal | `<leader><leader>` | Clear search highlights |
-| Visual | `>` / `<` | Indent while keeping the selection active |
+| <span class="shortcut-mode shortcut-mode--start">Normal</span> | `o` | Create a blank line below without staying in Insert mode |
+| <span class="shortcut-mode">Normal</span> | `O` | Create a blank line above without staying in Insert mode |
+| <span class="shortcut-mode">Normal</span> | <code>&lt;leader&gt;<wbr>&lt;leader&gt;</code> | Clear search highlights |
+| <span class="shortcut-mode shortcut-mode--start">Visual</span> | `>` / `<` | Indent while keeping the selection active |
 
 </section>
 


### PR DESCRIPTION
## Summary

- replace repeated tmux prefixes on mobile with one shared prefix summary and compact command/action rows
- group Neovim mappings by mode with mobile shortcut counts that stay correct while filtering
- preserve the existing desktop table presentation and fix the rendered pipe command

## Validation

- mise exec -- biome check docs/assets/stylesheets/mkdocs.css docs/assets/javascripts/site-shell.js
- mise run docs:build
- git diff --check
- browser regression checks at 320x568, 393x852, 430x932, and 1280x800
- light and dark schemes, tmux and Neovim filters, filtered mode-group promotion, and horizontal overflow checks