### PR TITLE
fix(docs): fingerprint custom assets

### DIFF
--- a/.github/actions/build-docs/action.yaml
+++ b/.github/actions/build-docs/action.yaml
@@ -20,4 +20,6 @@ runs:
 
     - name: Build
       shell: bash
-      run: zensical build --strict
+      run: |
+        zensical build --strict
+        python scripts/version_docs_assets.py

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,6 +8,7 @@ on:
       - "docs-overrides/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "scripts/version_docs_assets.py"
       - ".github/actions/build-docs/action.yaml"
       - ".github/workflows/docs.yaml"
   push:
@@ -18,6 +19,7 @@ on:
       - "docs-overrides/**"
       - "mkdocs.yml"
       - "requirements-docs.txt"
+      - "scripts/version_docs_assets.py"
       - ".github/actions/build-docs/action.yaml"
       - ".github/workflows/docs.yaml"
 

--- a/mise.toml
+++ b/mise.toml
@@ -27,7 +27,10 @@ raw = true
 
 [tasks."docs:build"]
 description = "Build the documentation with CI's strict settings"
-run = "uv run --python 3.14 --with-requirements requirements-docs.txt zensical build --strict"
+run = """
+uv run --python 3.14 --with-requirements requirements-docs.txt zensical build --strict
+uv run --python 3.14 python scripts/version_docs_assets.py
+"""
 
 [tasks.reconcile]
 description = "Install Ansible collections and reconcile this machine"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,11 +76,11 @@ plugins:
 
 extra_css:
   - assets/stylesheets/design-system.css
-  - assets/stylesheets/mkdocs.css?v=9cb3bb4
+  - assets/stylesheets/mkdocs.css
 
 extra_javascript:
   - assets/javascripts/syntax-highlight.js
-  - assets/javascripts/site-shell.js?v=9cb3bb4
+  - assets/javascripts/site-shell.js
 
 extra:
   generator: false

--- a/scripts/version_docs_assets.py
+++ b/scripts/version_docs_assets.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Add content hashes to custom documentation asset URLs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+from pathlib import Path
+
+ASSETS = (
+    Path("assets/stylesheets/mkdocs.css"),
+    Path("assets/javascripts/site-shell.js"),
+)
+
+
+def content_hash(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
+
+
+def version_assets(site_dir: Path) -> dict[Path, str]:
+    versions = {asset: content_hash(site_dir / asset) for asset in ASSETS}
+    replacements = dict.fromkeys(ASSETS, 0)
+
+    for html_path in site_dir.rglob("*.html"):
+        source = html_path.read_text(encoding="utf-8")
+        updated = source
+
+        for asset, version in versions.items():
+            reference = asset.as_posix()
+            pattern = rf"{re.escape(reference)}(?:\?v=[^\"']+)?(?=[\"'])"
+            updated, count = re.subn(
+                pattern,
+                f"{reference}?v={version}",
+                updated,
+            )
+            replacements[asset] += count
+
+        if updated != source:
+            html_path.write_text(updated, encoding="utf-8")
+
+    missing = [asset for asset, count in replacements.items() if count == 0]
+    if missing:
+        names = ", ".join(asset.as_posix() for asset in missing)
+        raise RuntimeError(f"No HTML references found for: {names}")
+
+    return versions
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "site_dir",
+        nargs="?",
+        type=Path,
+        default=Path("site"),
+        help="Built documentation directory (default: site)",
+    )
+    args = parser.parse_args()
+
+    versions = version_assets(args.site_dir)
+    for asset, version in versions.items():
+        print(f"Versioned {asset.as_posix()} as {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/version_docs_assets.py
+++ b/scripts/version_docs_assets.py
@@ -1,16 +1,21 @@
 #!/usr/bin/env python3
-"""Add content hashes to custom documentation asset URLs."""
+"""Add content hashes to local stylesheet and script URLs in a built site."""
 
 from __future__ import annotations
 
 import argparse
 import hashlib
+import html
 import re
 from pathlib import Path
+from urllib.parse import unquote, unquote_plus, urlsplit, urlunsplit
 
-ASSETS = (
-    Path("assets/stylesheets/mkdocs.css"),
-    Path("assets/javascripts/site-shell.js"),
+TAG_PATTERN = re.compile(r"<(?:link|script)\b[^>]*>", re.IGNORECASE)
+TAG_NAME_PATTERN = re.compile(r"<(?P<name>link|script)\b", re.IGNORECASE)
+ATTRIBUTE_PATTERN = re.compile(
+    r"(?P<name>[^\s=/>]+)(?P<separator>\s*=\s*)"
+    r"(?P<quote>['\"])(?P<value>.*?)(?P=quote)",
+    re.DOTALL,
 )
 
 
@@ -18,32 +23,114 @@ def content_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:12]
 
 
+def attributes(tag: str) -> dict[str, str]:
+    return {
+        match.group("name").lower(): html.unescape(match.group("value"))
+        for match in ATTRIBUTE_PATTERN.finditer(tag)
+    }
+
+
+def replace_attribute(tag: str, name: str, value: str) -> str:
+    escaped = html.escape(value, quote=True)
+
+    def replace(match: re.Match[str]) -> str:
+        if match.group("name").lower() != name:
+            return match.group(0)
+        return (
+            f"{match.group('name')}{match.group('separator')}"
+            f"{match.group('quote')}{escaped}{match.group('quote')}"
+        )
+
+    return ATTRIBUTE_PATTERN.sub(replace, tag)
+
+
+def asset_path(url: str, html_path: Path, site_dir: Path) -> Path | None:
+    parsed = urlsplit(url)
+    if parsed.scheme or parsed.netloc or not parsed.path:
+        return None
+
+    decoded_path = unquote(parsed.path)
+    if decoded_path.startswith("/"):
+        candidate = site_dir / decoded_path.lstrip("/")
+    else:
+        candidate = html_path.parent / decoded_path
+
+    site_root = site_dir.resolve()
+    candidate = candidate.resolve()
+    if not candidate.is_relative_to(site_root):
+        raise RuntimeError(f"Asset URL escapes the site directory: {url}")
+    if not candidate.is_file():
+        raise FileNotFoundError(f"Referenced asset does not exist: {candidate}")
+    return candidate
+
+
+def versioned_url(url: str, version: str) -> str:
+    parsed = urlsplit(url)
+    parameters = [
+        parameter
+        for parameter in parsed.query.split("&")
+        if parameter
+        and unquote_plus(parameter.partition("=")[0]).lower() != "v"
+    ]
+    parameters.append(f"v={version}")
+    return urlunsplit(parsed._replace(query="&".join(parameters)))
+
+
+def version_tag(
+    tag: str,
+    html_path: Path,
+    site_dir: Path,
+    versions: dict[Path, str],
+) -> str:
+    tag_name_match = TAG_NAME_PATTERN.match(tag)
+    if tag_name_match is None:
+        return tag
+
+    tag_name = tag_name_match.group("name").lower()
+    tag_attributes = attributes(tag)
+    if tag_name == "link":
+        relations = tag_attributes.get("rel", "").lower().split()
+        if "stylesheet" not in relations:
+            return tag
+        url_attribute = "href"
+    else:
+        url_attribute = "src"
+
+    url = tag_attributes.get(url_attribute)
+    if not url:
+        return tag
+
+    path = asset_path(url, html_path, site_dir)
+    if path is None:
+        return tag
+
+    version = versions.get(path)
+    if version is None:
+        version = versions[path] = content_hash(path)
+    return replace_attribute(tag, url_attribute, versioned_url(url, version))
+
+
 def version_assets(site_dir: Path) -> dict[Path, str]:
-    versions = {asset: content_hash(site_dir / asset) for asset in ASSETS}
-    replacements = dict.fromkeys(ASSETS, 0)
+    versions: dict[Path, str] = {}
 
     for html_path in site_dir.rglob("*.html"):
         source = html_path.read_text(encoding="utf-8")
-        updated = source
-
-        for asset, version in versions.items():
-            reference = asset.as_posix()
-            pattern = rf"{re.escape(reference)}(?:\?v=[^\"']+)?(?=[\"'])"
-            updated, count = re.subn(
-                pattern,
-                f"{reference}?v={version}",
-                updated,
-            )
-            replacements[asset] += count
-
+        updated = TAG_PATTERN.sub(
+            lambda match, html_path=html_path: version_tag(
+                match.group(0),
+                html_path,
+                site_dir,
+                versions,
+            ),
+            source,
+        )
         if updated != source:
             html_path.write_text(updated, encoding="utf-8")
 
-    missing = [asset for asset, count in replacements.items() if count == 0]
-    if missing:
-        names = ", ".join(asset.as_posix() for asset in missing)
-        raise RuntimeError(f"No HTML references found for: {names}")
-
+    if not versions:
+        raise RuntimeError(
+            f"No local stylesheets or scripts found in {site_dir}"
+        )
     return versions
 
 
@@ -59,8 +146,11 @@ def main() -> None:
     args = parser.parse_args()
 
     versions = version_assets(args.site_dir)
-    for asset, version in versions.items():
-        print(f"Versioned {asset.as_posix()} as {version}")
+    site_root = args.site_dir.resolve()
+    for asset, version in sorted(versions.items()):
+        print(
+            f"Versioned {asset.relative_to(site_root).as_posix()} as {version}"
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_version_docs_assets.py
+++ b/tests/unit/test_version_docs_assets.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.version_docs_assets import version_assets
+
+
+class VersionDocsAssetsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.site_dir = Path(self.temporary_directory.name).resolve()
+
+    def write(self, relative_path: str, content: str) -> Path:
+        path = self.site_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def digest(self, content: str) -> str:
+        return hashlib.sha256(content.encode()).hexdigest()[:12]
+
+    def test_versions_all_local_stylesheets_and_scripts(self) -> None:
+        base_css = self.write("assets/base.css", "base")
+        custom_css = self.write("assets/custom.css", "custom")
+        app_js = self.write("assets/app.js", "app")
+        index = self.write(
+            "guide/index.html",
+            """<!doctype html>
+<link rel="stylesheet" href="/assets/base.css">
+<link href='../assets/custom.css?v=old&amp;theme=dark#colors' rel='stylesheet'>
+<link rel="stylesheet" href="https://example.com/external.css">
+<link rel="icon" href="/assets/favicon.svg">
+<script defer src="../assets/app.js"></script>
+<script src="//cdn.example.com/external.js"></script>
+<script>console.log("inline")</script>
+""",
+        )
+
+        versions = version_assets(self.site_dir)
+
+        self.assertEqual(
+            versions,
+            {
+                base_css: self.digest("base"),
+                custom_css: self.digest("custom"),
+                app_js: self.digest("app"),
+            },
+        )
+        rendered = index.read_text(encoding="utf-8")
+        self.assertIn(f"/assets/base.css?v={self.digest('base')}", rendered)
+        self.assertIn(
+            f"../assets/custom.css?theme=dark&amp;v={self.digest('custom')}#colors",
+            rendered,
+        )
+        self.assertIn(f"../assets/app.js?v={self.digest('app')}", rendered)
+        self.assertIn("https://example.com/external.css", rendered)
+        self.assertIn("//cdn.example.com/external.js", rendered)
+        self.assertIn('rel="icon" href="/assets/favicon.svg"', rendered)
+
+    def test_second_run_is_idempotent(self) -> None:
+        self.write("assets/site.css", "style")
+        index = self.write(
+            "index.html",
+            '<link rel="stylesheet" href="assets/site.css">',
+        )
+
+        version_assets(self.site_dir)
+        first_run = index.read_text(encoding="utf-8")
+        version_assets(self.site_dir)
+
+        self.assertEqual(index.read_text(encoding="utf-8"), first_run)
+
+    def test_missing_local_asset_fails(self) -> None:
+        self.write(
+            "index.html",
+            '<script src="assets/missing.js"></script>',
+        )
+
+        with self.assertRaisesRegex(
+            FileNotFoundError,
+            "Referenced asset does not exist",
+        ):
+            version_assets(self.site_dir)
+
+    def test_asset_cannot_escape_site_directory(self) -> None:
+        outside = self.site_dir.parent / f"{self.site_dir.name}-outside.css"
+        outside.write_text("outside", encoding="utf-8")
+        self.addCleanup(outside.unlink)
+        self.write(
+            "index.html",
+            f'<link rel="stylesheet" href="../{outside.name}">',
+        )
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Asset URL escapes the site directory",
+        ):
+            version_assets(self.site_dir)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the hardcoded Git revision from documentation asset URLs
- discover every local stylesheet and script from the generated HTML
- derive a 12-character SHA-256 fingerprint from each referenced file and preserve existing query parameters and fragments
- apply the post-build step in both local mise tasks and GitHub Actions
- fail safely for missing assets or references that escape the generated site

## Verification

- `mise run docs:build`
- `python3 -m unittest discover -s tests/unit -v`
- `mise exec -- biome check docs/assets/stylesheets/mkdocs.css`
- `git diff --check`
- `prek run --all-files`
- Browser at 393 × 852: confirmed all seven local stylesheet/script URLs are versioned and load without console errors
- Browser: confirmed the Neovim filter, dark theme, `<leader><leader>`, and zero document overflow