### PR TITLE
chore(renovate): group bootstrap dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,6 +42,14 @@
       "semanticCommitScope": "deps"
     },
     {
+      "description": "Group dependencies used by the bootstrap runtime",
+      "matchFileNames": ["bootstrap/**"],
+      "groupName": "bootstrap dependencies",
+      "groupSlug": "bootstrap",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "bootstrap"
+    },
+    {
       "description": "Group Ansible content used to provision machines",
       "matchManagers": ["ansible-galaxy"],
       "matchFileNames": ["scripts/common/ansible/requirements.yml"],


### PR DESCRIPTION
## Summary

- group dependencies declared under `bootstrap/**` into a dedicated Renovate update
- use the `bootstrap` branch slug and `chore(bootstrap)` semantic commit scope
- keep the existing root Dockerfile/container-image grouping unchanged

This makes updates such as `.python-version` and `pyproject.toml` resolve to a clear `chore(bootstrap): update bootstrap dependencies` proposal instead of inheriting manager-specific wording such as "Python Docker tag". Associated `uv.lock` changes remain part of the same update.

## Validation

- `npx --yes --package renovate@44.49.0 renovate-config-validator .github/renovate.json`
- repository pre-commit hooks