### PR TITLE
chore(renovate): remove redundant update titles

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
       "description": "Group documentation build dependencies",
       "matchManagers": ["pip_requirements"],
       "matchFileNames": ["requirements-docs.txt"],
-      "groupName": "documentation dependencies",
+      "groupName": "build dependencies",
       "groupSlug": "docs",
       "semanticCommitType": "docs",
       "semanticCommitScope": "deps"
@@ -44,7 +44,7 @@
     {
       "description": "Group dependencies used by the bootstrap runtime",
       "matchFileNames": ["bootstrap/**"],
-      "groupName": "bootstrap dependencies",
+      "groupName": "runtime dependencies",
       "groupSlug": "bootstrap",
       "semanticCommitType": "chore",
       "semanticCommitScope": "bootstrap"
@@ -62,16 +62,16 @@
       "description": "Group tools used to develop and validate this repository",
       "matchManagers": ["mise"],
       "matchFileNames": ["mise.toml"],
-      "groupName": "repository toolchain",
-      "groupSlug": "repo-toolchain",
+      "groupName": "development dependencies",
+      "groupSlug": "development-dependencies",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
     {
-      "description": "Include pre-commit hooks in the repository toolchain group",
+      "description": "Include pre-commit hooks in the development dependency group",
       "matchManagers": ["pre-commit"],
-      "groupName": "repository toolchain",
-      "groupSlug": "repo-toolchain",
+      "groupName": "development dependencies",
+      "groupSlug": "development-dependencies",
       "semanticCommitType": "chore",
       "semanticCommitScope": "tooling"
     },
@@ -79,7 +79,7 @@
       "description": "Keep workstation changes separate from repository tooling",
       "matchManagers": ["mise"],
       "matchFileNames": ["config/private_dot_config/mise/config.toml"],
-      "groupName": "workstation toolchain",
+      "groupName": "toolchain",
       "groupSlug": "workstation-toolchain",
       "semanticCommitType": "chore",
       "semanticCommitScope": "workstation"


### PR DESCRIPTION
## Summary

Refine Renovate group names so the generated update topic complements the semantic commit prefix instead of repeating information already encoded there.

| Area | Previous title | Proposed title |
| --- | --- | --- |
| Documentation | `docs(deps): update documentation dependencies` | `docs(deps): update build dependencies` |
| Bootstrap | `chore(bootstrap): update bootstrap dependencies` | `chore(bootstrap): update runtime dependencies` |
| Repository tooling | `chore(tooling): update repository toolchain` | `chore(tooling): update development dependencies` |
| Workstation | `chore(workstation): update workstation toolchain` | `chore(workstation): update toolchain` |

The GitHub Actions, Ansible provisioning, and container image groups already add information beyond their semantic prefixes, so their names remain unchanged. The repository-tooling branch slug changes from `repo-toolchain` to `development-dependencies` to remain consistent with its refined group name.

## Validation

- `npx --yes --package renovate@44.49.0 renovate-config-validator .github/renovate.json`
- repository pre-commit hooks