### PR TITLE
fix(renovate): cover locked bootstrap dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,18 +47,10 @@
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Group GitHub Actions version updates",
+      "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "GitHub Actions",
       "groupSlug": "github-actions"
-    },
-    {
-      "description": "Group GitHub Actions digest updates",
-      "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["digest", "pinDigest"],
-      "groupName": "GitHub Actions digests",
-      "groupSlug": "github-actions-digests"
     },
     {
       "description": "Group documentation build dependencies",
@@ -119,20 +111,11 @@
       "semanticCommitScope": "deps"
     },
     {
-      "description": "Group Docker version updates",
+      "description": "Group Docker updates",
       "matchManagers": ["dockerfile"],
       "matchFileNames": ["**/Dockerfile"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
       "groupName": "container images",
       "groupSlug": "container-images"
-    },
-    {
-      "description": "Group Docker digest updates",
-      "matchManagers": ["dockerfile"],
-      "matchFileNames": ["**/Dockerfile"],
-      "matchUpdateTypes": ["digest", "pinDigest"],
-      "groupName": "container image digests",
-      "groupSlug": "container-image-digests"
     },
     {
       "description": "Keep bootstrap Python declarations synchronized",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:best-practices", ":enablePreCommit"],
+  "ignorePresets": [":ignoreModulesAndTests"],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/examples/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/__fixtures__/**"
+  ],
   "timezone": "Europe/Warsaw",
   "schedule": ["* 0-5 * * 1"],
   "updateNotScheduled": false,
   "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "prConcurrentLimit": 4,
   "prHourlyLimit": 2,
   "rebaseWhen": "conflicted",
@@ -13,24 +24,41 @@
   "major": {
     "dependencyDashboardApproval": true
   },
-  "lockFileMaintenance": {
-    "enabled": false
-  },
   "vulnerabilityAlerts": {
     "enabled": true,
-    "schedule": ["at any time"],
-    "minimumReleaseAge": "0 days",
     "semanticCommitType": "fix",
     "semanticCommitScope": "security"
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update annotated shell variables",
+      "managerFilePatterns": ["/^scripts\\/setup\\.sh$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+[A-Za-z_][A-Za-z0-9_]*=(?<currentValue>\\S+)"
+      ]
+    }
+  ],
   "packageRules": [
     {
-      "description": "Group updates across the repository's GitHub Actions",
+      "description": "Use CI commit semantics for GitHub Actions",
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions",
-      "groupSlug": "github-actions",
       "semanticCommitType": "ci",
       "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Group GitHub Actions version updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
+    },
+    {
+      "description": "Group GitHub Actions digest updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "groupName": "GitHub Actions digests",
+      "groupSlug": "github-actions-digests"
     },
     {
       "description": "Group documentation build dependencies",
@@ -85,13 +113,55 @@
       "semanticCommitScope": "workstation"
     },
     {
-      "description": "Group the runtime and frontend images used by Docker builds",
+      "description": "Use build commit semantics for Docker dependencies",
       "matchManagers": ["dockerfile"],
-      "matchFileNames": ["Dockerfile"],
-      "groupName": "container images",
-      "groupSlug": "container-images",
       "semanticCommitType": "build",
       "semanticCommitScope": "deps"
+    },
+    {
+      "description": "Group Docker version updates",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["**/Dockerfile"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "container images",
+      "groupSlug": "container-images"
+    },
+    {
+      "description": "Group Docker digest updates",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": ["**/Dockerfile"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "groupName": "container image digests",
+      "groupSlug": "container-image-digests"
+    },
+    {
+      "description": "Keep bootstrap Python declarations synchronized",
+      "matchDepNames": ["python"],
+      "matchFileNames": [
+        "bootstrap/.python-version",
+        "bootstrap/pyproject.toml"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "bootstrap Python",
+      "groupSlug": "bootstrap-python",
+      "minimumGroupSize": 2,
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "bootstrap"
+    },
+    {
+      "description": "Keep bootstrap uv declarations synchronized",
+      "matchDepNames": ["uv", "astral-sh/uv", "ghcr.io/astral-sh/uv"],
+      "matchFileNames": [
+        "mise.toml",
+        "scripts/setup.sh",
+        "tests/integration/Dockerfile"
+      ],
+      "matchUpdateTypes": ["major", "minor", "patch"],
+      "groupName": "bootstrap uv",
+      "groupSlug": "bootstrap-uv",
+      "minimumGroupSize": 3,
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "bootstrap"
     },
     {
       "description": "Allow for the slower release cadence of stable tooling",

--- a/bootstrap/pyproject.toml
+++ b/bootstrap/pyproject.toml
@@ -5,4 +5,5 @@ requires-python = "==3.13.15"
 dependencies = ["ansible-core==2.21.3"]
 
 [tool.uv]
+exclude-newer = "3 days"
 package = false

--- a/bootstrap/uv.lock
+++ b/bootstrap/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = "==3.13.15"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "ansible-core"
 version = "2.21.3"

--- a/scripts/validate_bootstrap_runtime.py
+++ b/scripts/validate_bootstrap_runtime.py
@@ -49,10 +49,31 @@ def configured_uv_version() -> str:
 
     with (REPOSITORY_ROOT / "mise.toml").open("rb") as mise_file:
         mise_version = tomllib.load(mise_file)["tools"]["uv"]
-    if setup_version != mise_version:
+
+    integration_text = (
+        REPOSITORY_ROOT / "tests/integration/Dockerfile"
+    ).read_text()
+    integration_match = re.search(
+        r"^FROM ghcr\.io/astral-sh/uv:([^@\s]+)(?:@sha256:[0-9a-f]+)? AS uv$",
+        integration_text,
+        re.MULTILINE,
+    )
+    if integration_match is None:
+        fail("tests/integration/Dockerfile does not declare one uv image")
+    integration_version = integration_match.group(1)
+
+    versions = {
+        "scripts/setup.sh": setup_version,
+        "mise.toml": mise_version,
+        "tests/integration/Dockerfile": integration_version,
+    }
+    if len(set(versions.values())) != 1:
         fail(
             "uv version drift: "
-            f"scripts/setup.sh declares {setup_version}, mise.toml declares {mise_version}"
+            + ", ".join(
+                f"{path} declares {version}"
+                for path, version in versions.items()
+            )
         )
     return setup_version
 


### PR DESCRIPTION
## Summary

- restore weekly lock-file maintenance from config:best-practices and enforce the same three-day cooldown for transitive uv resolution
- scan tracked test dependencies and activate the annotated scripts/setup.sh uv version through a regex custom manager
- allow dependencies without release timestamps while preserving the cooldown where timestamps exist
- keep duplicated Python and uv declarations atomic and validate all three uv pins at runtime
- group Docker and GitHub Actions updates while relying on Renovate to deduplicate overlapping version and digest candidates
- remove redundant vulnerability-alert overrides

## Validation

- mise exec -- prek run --all-files
- mise exec -- uv lock --project bootstrap --check
- mise run ansible:validate-runtime
- Renovate 44.52.1 local extraction: 16 package files and 83 dependencies
- Renovate 44.52.1 authenticated local lookup confirms version updates take precedence over redundant digest refreshes