### PR TITLE
fix: install Alacritty from personal tap

### DIFF
--- a/bootstrap/ansible/config.yaml
+++ b/bootstrap/ansible/config.yaml
@@ -21,9 +21,10 @@ bootstrap_linux_packages:
 brew:
   taps:
     - carlocab/personal
+    - shmileee/tap
   casks:
     - 1password
-    - alacritty
+    - shmileee/tap/alacritty
     - alt-tab
     - aws-vault
     - chatgpt


### PR DESCRIPTION
## Why

This fixes Alacritty provisioning before the official Homebrew cask is disabled tomorrow, September 1, 2026, because it fails Gatekeeper checks. Without this change, fresh dotfiles setups and future Homebrew-managed Alacritty installs would fail once the disablement takes effect.

## Summary

- tap `shmileee/tap` during Homebrew provisioning
- replace the disabled official `alacritty` cask with `shmileee/tap/alacritty`
- keep using the upstream prebuilt DMG; nothing is compiled from source

## Safety check

- the custom cask resolves to upstream Alacritty 0.17.0 and its SHA-256 matches the published DMG (`ad8d7de35fb38e43184776cac6dfee05ca325caa0b6639a06a55e54e4b026620`)
- its app, binary, terminfo, manpage, and completion artifacts match the official cask
- its only behavioral addition is a non-fatal postflight removal of the app quarantine attribute
- uninstall zap paths do not include `~/.config/alacritty`; the managed Alacritty template is unchanged and renders successfully
- local verification was read-only: this workstation remains on the official `homebrew/cask` Alacritty 0.17.0, and no tap/cask/app/config/quarantine state was changed

## Validation

- `prek run --all-files`
- `bats tests/bootstrap` (24 tests)
- `yamllint` and `ansible-lint`
- custom cask Ruby syntax check
- streamed upstream DMG checksum verification
- Alacritty chezmoi template render and unchanged-file check