### PR TITLE
chore(ci): standardize github actions naming

### DIFF
--- a/.github/actions/build-docs/action.yaml
+++ b/.github/actions/build-docs/action.yaml
@@ -1,15 +1,15 @@
 ---
-name: Build documentation
-description: Install the pinned documentation toolchain and build the site
+name: build site
+description: install the pinned documentation toolchain and build the site
 
 runs:
   using: composite
   steps:
-    - name: Set up mise
+    - name: set up mise
       uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
         install_args: uv
 
-    - name: Build
+    - name: build site
       shell: bash
       run: mise run docs:build

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,5 +1,5 @@
 ---
-name: validate
+name: checks
 
 on:
   pull_request:
@@ -14,26 +14,26 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  static:
-    name: Validate repository
+  lint:
+    name: lint and test
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GITHUB_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Set up mise
+      - name: set up mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
-      - name: Install Fish
+      - name: install fish
         run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends fish
 
-      - name: Validate Fish syntax and templates
+      - name: check fish syntax and templates
         run: |
           find config -type f -name '*.fish' -exec fish --no-execute {} +
 
@@ -41,18 +41,18 @@ jobs:
             mise exec -- chezmoi execute-template < "$template" | fish --no-execute
           done < <(find config -type f -name '*.fish.tmpl' -print0)
 
-      - name: Restore Ansible collections
+      - name: restore ansible collections
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: bootstrap/.ansible/collections
           key: ${{ runner.os }}-ansible-${{ hashFiles('bootstrap/uv.lock', 'bootstrap/ansible/requirements.yml') }}
 
-      - name: Run repository checks
+      - name: validate runtime and run lint
         run: |
           mise run ansible:validate-runtime
           mise run lint
 
-      - name: Validate Ansible syntax
+      - name: check ansible syntax
         run: |
           mise exec -- env \
             ANSIBLE_CONFIG=bootstrap/ansible/ansible.cfg \
@@ -61,5 +61,5 @@ jobs:
             --inventory "127.0.0.1," \
             --syntax-check bootstrap/ansible/main.yaml
 
-      - name: Test local Ansible module helpers
+      - name: test ansible module helpers
         run: python3 -m unittest discover -s tests/unit -v

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -43,18 +43,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  bootstrap-behavior:
-    name: Test bootstrap behavior on the runner
+  bootstrap:
+    name: test bootstrap
     runs-on: ${{ vars.UBUNTU_ARM_RUNNER }}
     timeout-minutes: 15
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Verify the public bootstrap redirect
+      - name: verify bootstrap redirect
         run: |
           repository_slug="$(./bootstrap/setup.sh --print-config | sed -n 's/^repository_slug=//p')"
           repository_ref="$(./bootstrap/setup.sh --print-config | sed -n 's/^repository_ref=//p')"
@@ -62,30 +62,30 @@ jobs:
           target="$(curl -fsSIL -o /dev/null --write-out '%{url_effective}' "$bootstrap_url")"
           test "$target" = "https://raw.githubusercontent.com/$repository_slug/$repository_ref/bootstrap/setup.sh"
 
-      - name: Set up mise
+      - name: set up mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           install_args: aqua:bats-core/bats-core
 
-      - name: Run Bats behavior tests
+      - name: run bats tests
         run: mise run test:bats
 
-  docker-integration:
-    name: Test Ansible bootstrap integration in Docker
+  integration:
+    name: test integration
     runs-on: ${{ vars.UBUNTU_ARM_RUNNER }}
     timeout-minutes: 20
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Build the integration image
+      - name: build integration image
         run: docker build --file tests/integration/Dockerfile --tag dotfiles-bootstrap-tests .
 
-  build-test-publish:
-    name: Build, test, and publish image
+  image:
+    name: ${{ github.event_name == 'push' && 'test and publish image' || 'test image' }}
     runs-on: ${{ vars.UBUNTU_ARM_RUNNER }}
     timeout-minutes: 45
     env:
@@ -94,15 +94,15 @@ jobs:
       DOTFILES_PERSISTENT_REFSPEC: +${{ github.ref }}:refs/remotes/origin/ci
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Set up Docker Buildx
+      - name: set up buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
 
-      - name: Build test image
+      - name: build test image
         uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
@@ -122,17 +122,17 @@ jobs:
           secrets: |
             GITHUB_TOKEN=${{ github.token }}
 
-      - name: Smoke-test image and second provisioning pass
+      - name: run smoke and idempotency tests
         run: tests/integration/workstation-smoke.sh dotfiles:test
 
-      - name: Login to DockerHub
+      - name: sign in to docker hub
         if: github.event_name == 'push'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish tested image
+      - name: publish image
         if: github.event_name == 'push'
         env:
           SHA_TAG: ${{ github.sha }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,37 +25,23 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  build:
-    name: Build documentation
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-        with:
-          persist-credentials: false
-
-      - name: Build documentation
-        uses: ./.github/actions/build-docs
-
-  deploy:
-    name: Build and deploy documentation
-    if: github.event_name == 'push'
+  site:
+    name: ${{ github.event_name == 'push' && 'publish' || 'build' }}
     permissions:
       contents: write # Push the generated site to the gh-pages branch.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Build documentation
+      - name: build site
         uses: ./.github/actions/build-docs
 
-      - name: Deploy
+      - name: deploy site
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -34,30 +34,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bootstrap-behavior:
-    name: Test POSIX bootstrap on macOS
+  bootstrap:
+    name: test bootstrap
     runs-on: macos-latest
     timeout-minutes: 20
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Set up mise
+      - name: set up mise
         uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
           install_args: aqua:bats-core/bats-core
 
-      - name: Install Dash
+      - name: install dash
         run: brew install dash
 
-      - name: Test the loader under Dash and macOS /bin/sh
+      - name: test with dash and /bin/sh
         run: mise run test:bats
 
-  macos:
-    name: Provision through the checked-out setup and verify macOS
+  provision:
+    name: verify provisioning
     runs-on: macos-latest
     timeout-minutes: 60
     env:
@@ -70,12 +70,12 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: "1"
 
     steps:
-      - name: Checkout
+      - name: checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
-      - name: Reset Homebrew formulae
+      - name: reset homebrew formulae
         run: |
           # The runner image can contain mise environments backed by Homebrew
           # interpreters removed below. Discard only those ephemeral installs
@@ -94,16 +94,16 @@ jobs:
           # Ansible installs any configured applications that are missing.
           brew cleanup --prune-prefix
 
-      - name: Install through the checked-out POSIX setup
+      - name: install through local setup
         run: ./bootstrap/setup.sh
 
-      - name: Validate
+      - name: install tools and run lint
         run: |
           cd "$HOME/ghq/personalgit/$GITHUB_REPOSITORY"
           mise install
           mise run lint
 
-      - name: Verify a second run is idempotent
+      - name: verify idempotency
         run: |
           cd "$HOME/ghq/personalgit/$GITHUB_REPOSITORY"
           mise run reconcile | tee /tmp/ansible-idempotence.log

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,4 +9,4 @@ and each tool's native update workflow.
 
 [![macos](https://github.com/shmileee/dotfiles/actions/workflows/macos.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/macos.yaml)
 [![docker](https://github.com/shmileee/dotfiles/actions/workflows/docker.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/docker.yaml)
-[![validate](https://github.com/shmileee/dotfiles/actions/workflows/validate.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/validate.yaml)
+[![checks](https://github.com/shmileee/dotfiles/actions/workflows/checks.yaml/badge.svg)](https://github.com/shmileee/dotfiles/actions/workflows/checks.yaml)


### PR DESCRIPTION
## summary

- make workflow, job, action, and step names consistently lowercase
- shorten job names while preserving workflow context
- consolidate docs build and publish paths into one event-aware job
- rename the validate workflow to checks and update its badge

## testing

- `mise run lint`