### PR TITLE
fix(config): remove obsolete workstation settings

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -103,6 +103,15 @@ jobs:
           mise install
           mise run lint
 
+      - name: verify managed runtime dependencies
+        run: |
+          test "$(command -v bash)" = /opt/homebrew/bin/bash
+          bash -c '(( BASH_VERSINFO[0] >= 4 ))'
+          command -v git-lfs
+          command -v session-manager-plugin
+          test "$(git config --file "$HOME/.config/git/personal" --get commit.gpgsign)" = true
+          test "$(git config --file "$HOME/.config/git/personal" --get gpg.ssh.program)" = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
+
       - name: verify idempotency
         run: |
           cd "$HOME/ghq/personalgit/$GITHUB_REPOSITORY"

--- a/bootstrap/ansible/config.yaml
+++ b/bootstrap/ansible/config.yaml
@@ -17,6 +17,7 @@ bootstrap_linux_packages:
   - unzip
   - vim
   - wget
+  - xclip
 
 brew:
   taps:
@@ -32,6 +33,7 @@ brew:
     - kdiff3
     - microsoft-outlook
     - rectangle
+    - session-manager-plugin
     - slack
     - spotify
     - telegram
@@ -48,6 +50,7 @@ brew:
       - gh
       - ghq
       - git-delta
+      - git-lfs
       - highlight
       - jq
       - lazygit
@@ -58,6 +61,7 @@ brew:
       - tree
       - zoxide
     darwin:
+      - bash
       - carlocab/personal/unrar
       - dockutil
       - switchaudio-osx

--- a/bootstrap/ansible/roles/fish/tasks/main.yaml
+++ b/bootstrap/ansible/roles/fish/tasks/main.yaml
@@ -14,7 +14,7 @@
         (
           '/home/linuxbrew/.linuxbrew'
           if ansible_facts['system'] == 'Linux'
-          else ('/opt/homebrew' if ansible_facts['architecture'] == 'arm64' else '/usr/local')
+          else '/opt/homebrew'
         ) + '/bin/fish'
       }}
 

--- a/bootstrap/ansible/roles/system_defaults/defaults/main.yaml
+++ b/bootstrap/ansible/roles/system_defaults/defaults/main.yaml
@@ -52,7 +52,7 @@ osx_global_defaults:
   #########################################
 
   - { name: "orient macos dock to the bottom of the screen", domain: com.apple.dock, key: orientation, type: string, value: bottom }
-  - { name: "set the icon size of dock items to 42 pixels (monterrey)", domain: com.apple.dock, key: tilesize, type: float, value: 42 }
+  - { name: "set the icon size of dock items to 42 pixels", domain: com.apple.dock, key: tilesize, type: float, value: 42 }
   - { name: "remove the auto-hiding dock delay", domain: com.apple.dock, key: autohide-delay, type: float, value: 0.0 }
   - { name: "remove the animation when hiding/showing the dock", domain: com.apple.dock, key: autohide-time-modifier, type: float, value: 0.0 }
   - { name: "automatically hide and show the dock", domain: com.apple.dock, key: autohide, type: bool, value: true }

--- a/config/bin/executable_exec-atlantis
+++ b/config/bin/executable_exec-atlantis
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if ((BASH_VERSINFO[0] < 4)); then
+  printf 'exec-atlantis requires Bash 4 or newer; found %s.\n' "${BASH_VERSION}" >&2
+  exit 1
+fi
+
 aws_profile=iris-operations
 aws_region=eu-west-1
 ecs_cluster=atlantis

--- a/config/bin/executable_rg-sed
+++ b/config/bin/executable_rg-sed
@@ -87,8 +87,6 @@ def run():
                     content[line_num] = new_text + "\n"
                 if edit:
                     to_be_edited.append(line_num + 1)
-        except:
-            raise
         finally:
             with open(filename, "w") as f:
                 f.writelines(content)

--- a/config/bin/executable_ssm-session.tmpl
+++ b/config/bin/executable_ssm-session.tmpl
@@ -1,9 +1,10 @@
+{{- if eq .chezmoi.os "darwin" -}}
 #!/usr/bin/env bash
 #
-# Based on https://github.com/corrupt952/ssm-session
-#
 # Requirements:
-#   - fzf (brew install fzf)
+#   - AWS CLI
+#   - Session Manager plugin
+#   - fzf
 #
 # Usage:
 #
@@ -58,3 +59,4 @@ case "$1" in
     print_usage
     ;;
 esac
+{{ end -}}

--- a/config/bin/executable_switch-audio
+++ b/config/bin/executable_switch-audio
@@ -6,8 +6,8 @@
 # Usage:
 #
 #   Switch between speakers / headphones:
-#   - audio headphones
-#   - audio speakers
+#   - switch-audio headphones
+#   - switch-audio speakers
 #
 
 if ! command -v "SwitchAudioSource" &> /dev/null; then

--- a/config/private_dot_config/nvim/lua/config/autocmds.lua
+++ b/config/private_dot_config/nvim/lua/config/autocmds.lua
@@ -7,14 +7,3 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
     vim.b.autoformat = false
   end,
 })
-
--- Fix Helm syntax highlighting
-vim.api.nvim_create_autocmd({ "BufRead", "BufEnter" }, {
-  pattern = "*.yaml",
-  callback = function()
-    if vim.bo[vim.api.nvim_get_current_buf()].filetype == "helm" then
-      vim.cmd("TSToggle highlight")
-      vim.cmd("TSToggle highlight")
-    end
-  end,
-})

--- a/config/private_dot_config/private_fish/conf.d/alias.fish.tmpl
+++ b/config/private_dot_config/private_fish/conf.d/alias.fish.tmpl
@@ -55,5 +55,3 @@ end
 
 # toggle between audio devices
 alias s 'command switch-audio'
-
-alias assume 'source /usr/local/bin/assume.fish'

--- a/config/private_dot_config/private_fish/private_config.fish.tmpl
+++ b/config/private_dot_config/private_fish/private_config.fish.tmpl
@@ -18,7 +18,11 @@ fish_add_path /opt/homebrew/opt/libpq/bin
 
 set -gx HOMEBREW_NO_ANALYTICS 1
 
+{{- if eq .chezmoi.os "darwin" }}
+set -gx DIRENV_BASH /opt/homebrew/bin/bash
+{{- else }}
 set -gx DIRENV_BASH /bin/bash
+{{- end }}
 
 if status is-interactive
     if type -q bat

--- a/config/private_dot_config/private_git/config.tmpl
+++ b/config/private_dot_config/private_git/config.tmpl
@@ -35,7 +35,6 @@
 {{- end }}
 [pull]
   rebase = false
-  default = current
 [init]
   defaultBranch = main
 [push]

--- a/config/private_dot_config/private_git/personal.tmpl
+++ b/config/private_dot_config/private_git/personal.tmpl
@@ -2,9 +2,11 @@
 	email = ponomarov.aleksandr@gmail.com
 	name = shmileee
 	signingkey = ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAICmPDgaUnEugEQdbio+K77tigQhwwlErx6jApEhR0tw8
+{{- if eq .chezmoi.os "darwin" }}
 [gpg]
 	format = ssh
 [gpg "ssh"]
 	program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign"
 [commit]
 	gpgsign = true
+{{- end }}

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -284,7 +284,8 @@ documentation in multiple places. At minimum, replace or review:
 On macOS, the Homebrew role downloads the current signed `Homebrew.pkg` and
 installs it through Ansible's become mechanism. On Ubuntu, Ansible first creates
 the user-owned Linuxbrew prefix, then runs Homebrew's current shell installer
-without sudo. Neither installer needs access to the user's password.
+without sudo. The macOS package installation and Ubuntu prefix preparation may
+prompt for the user's sudo password through Ansible.
 
 ## Routine work with mise
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,1 +1,0 @@
-{% extends "base.html" %}

--- a/tests/integration/workstation-smoke.sh
+++ b/tests/integration/workstation-smoke.sh
@@ -23,14 +23,18 @@ docker run --rm --entrypoint /bin/bash "$image" -lc '
   test -z "$(git config --local --get remote.origin.promisor || true)"
 
   printf "%s\n" "SMOKE phase=executables"
-  for executable in brew chezmoi fish mise tmux; do
+  for executable in bash brew chezmoi fish git-lfs mise tmux xclip; do
     command -v "$executable" >/dev/null
   done
+  bash -c "(( BASH_VERSINFO[0] >= 4 ))"
   mise exec -- ansible-lint --version >/dev/null
   mise exec -- yamllint --version >/dev/null
 
   printf "%s\n" "SMOKE phase=startup"
   test -z "$(fish -c true)"
+  test ! -e "$HOME/bin/ssm-session"
+  test -z "$(git config --file "$HOME/.config/git/personal" --get commit.gpgsign || true)"
+  test -z "$(git config --file "$HOME/.config/git/personal" --get gpg.ssh.program || true)"
   mise exec -- nvim --headless +qa
 
   printf "%s\n" "SMOKE phase=idempotence"


### PR DESCRIPTION
## Summary

- provision modern Bash, Git LFS, and Linux clipboard support
- remove obsolete Neovim, Git, Fish, Python, and documentation configuration
- keep Session Manager and 1Password signing macOS-only
- add cross-platform provisioning regression checks

## Validation

- mise run lint
- python3 -m unittest discover -s tests/unit -v
- mise run test:bats
- mise run docs:build
- mise run ansible:validate-runtime
- Ansible syntax check
- Ubuntu provisioning and idempotency verification