### PR TITLE
fix(config): remove unused maven tool

### DIFF
--- a/config/private_dot_config/mise/config.toml
+++ b/config/private_dot_config/mise/config.toml
@@ -21,7 +21,6 @@ legacy_version_file = false
 bun = "1.4.0"
 go = "1.26.7"
 golangci-lint = "2.13.2"
-maven = "3.9.16"
 node = "24.18.1"
 prek = "0.4.14"
 python = "3.14.7"


### PR DESCRIPTION
## Why

The `test and publish image` job failed in [run 33964350749](https://github.com/shmileee/dotfiles/actions/runs/33964350749/job/101301669185): `mise install` errored out on `aqua:apache/maven@3.9.16` with repeated TCP connect timeouts against `archive.apache.org` — the only mirror aqua's registry uses, and a chronically throttled endpoint.

## What

Remove `maven` from the workstation mise config (`config/private_dot_config/mise/config.toml`). It's unused, so dropping it beats mirroring it (an `http:` backend pin against Maven Central was validated as an alternative, but there's no point installing a tool nobody uses).

This was the sole reference to maven in the repo, so `archive.apache.org` is out of the provisioning path entirely.