### PR TITLE
fix(bootstrap): make the sudo password prompt tty-safe and tested

### DIFF
--- a/bootstrap/reconcile.sh
+++ b/bootstrap/reconcile.sh
@@ -111,13 +111,18 @@ fi
 # password as a variable (wired to SUDO_ASKPASS), so it is captured here and
 # handed to the playbook through the environment.
 if ! sudo -k -n true > /dev/null 2>&1; then
-  printf '[dotfiles] Sudo needs the workstation password (become tasks + Homebrew pkg installers): '
-  stty -echo < /dev/tty
-  read -r DOTFILES_BECOME_PASSWORD < /dev/tty || {
-    stty echo < /dev/tty
+  become_tty=${DOTFILES_TTY_DEVICE:-/dev/tty}
+  if ! (: < "$become_tty") 2> /dev/null; then
+    printf '[dotfiles] Sudo needs the workstation password but no terminal is available to ask for it.\n' >&2
     exit 1
-  }
-  stty echo < /dev/tty
+  fi
+  printf '[dotfiles] Sudo needs the workstation password (become tasks + Homebrew pkg installers): '
+  stty -echo < "$become_tty" 2> /dev/null || :
+  if ! read -r DOTFILES_BECOME_PASSWORD < "$become_tty"; then
+    stty echo < "$become_tty" 2> /dev/null || :
+    exit 1
+  fi
+  stty echo < "$become_tty" 2> /dev/null || :
   printf '\n'
   if ! printf '%s\n' "$DOTFILES_BECOME_PASSWORD" | sudo -k -S true > /dev/null 2>&1; then
     printf '[dotfiles] The sudo password was not accepted.\n' >&2

--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -380,14 +380,18 @@ run_ansible() {
   # sudo password as a variable (wired to SUDO_ASKPASS), so it is captured
   # here and handed to the playbook through the environment.
   if ! sudo -k -n true > /dev/null 2>&1; then
+    become_tty=${DOTFILES_TTY_DEVICE:-/dev/tty}
+    if ! (: < "$become_tty") 2> /dev/null; then
+      fail 'sudo needs the workstation password but no terminal is available to ask for it.'
+    fi
     phase 'Sudo needs the workstation password; it is asked for once'
     printf 'Workstation password: '
-    stty -echo < /dev/tty
-    read -r DOTFILES_BECOME_PASSWORD < /dev/tty || {
-      stty echo < /dev/tty
+    stty -echo < "$become_tty" 2> /dev/null || :
+    if ! read -r DOTFILES_BECOME_PASSWORD < "$become_tty"; then
+      stty echo < "$become_tty" 2> /dev/null || :
       fail 'could not read the sudo password from the terminal.'
-    }
-    stty echo < /dev/tty
+    fi
+    stty echo < "$become_tty" 2> /dev/null || :
     printf '\n'
     if ! printf '%s\n' "$DOTFILES_BECOME_PASSWORD" | sudo -k -S true > /dev/null 2>&1; then
       fail 'the sudo password was not accepted.'

--- a/tests/bootstrap/bootstrap.bats
+++ b/tests/bootstrap/bootstrap.bats
@@ -290,25 +290,55 @@ teardown() {
   [ -z "$(find "$test_tmp" -mindepth 1 -print -quit)" ]
 }
 
-@test "passwordless sudo omits the become prompt flag" {
+@test "passwordless sudo skips the password prompt" {
   TEST_SUDO_STATUS=0
 
   run_bootstrap
 
   [ "$status" -eq 0 ]
   assert_log_contains "sudo -k -n true"
-  refute_log_contains "--ask-become-pass"
+  refute_log_contains "sudo -k -S true"
+  [[ $output != *"Workstation password"* ]]
 }
 
-@test "a failed passwordless probe delegates one password prompt to Ansible" {
+@test "a failed passwordless probe captures one password for Ansible" {
   TEST_SUDO_STATUS=1
+  printf 'workstation-secret\n' > "$test_root/tty-input"
+  TEST_TTY_DEVICE=$test_root/tty-input
 
   run_bootstrap
 
   [ "$status" -eq 0 ]
   assert_log_contains "sudo -k -n true"
-  assert_log_contains "--ask-become-pass"
-  [[ $output == *"Ansible will ask once"* ]]
+  assert_log_contains "sudo -k -S true"
+  assert_log_contains "sudo-password workstation-secret"
+  assert_log_contains "ansible-playbook --inventory 127.0.0.1,"
+  [[ $output == *"Sudo needs the workstation password"* ]]
+}
+
+@test "a rejected sudo password stops bootstrap" {
+  TEST_SUDO_STATUS=1
+  TEST_SUDO_PASSWORD_STATUS=1
+  printf 'wrong-secret\n' > "$test_root/tty-input"
+  TEST_TTY_DEVICE=$test_root/tty-input
+
+  run_bootstrap
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"the sudo password was not accepted."* ]]
+  refute_log_contains "ansible-playbook --inventory 127.0.0.1,"
+}
+
+@test "sudo needing a password without a terminal is actionable" {
+  TEST_SUDO_STATUS=1
+  TEST_TTY_DEVICE=$test_root/absent-tty
+
+  run_bootstrap
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"no terminal is available"* ]]
+  refute_log_contains "sudo -k -S true"
+  refute_log_contains "ansible-playbook --inventory 127.0.0.1,"
 }
 
 @test "phase messages are ordered and completion is actionable" {

--- a/tests/bootstrap/test-helper.bash
+++ b/tests/bootstrap/test-helper.bash
@@ -56,7 +56,14 @@ EOF
 
   make_mock sudo << 'EOF'
 printf 'sudo %s\n' "$*" >>"$MOCK_LOG"
-exit "${TEST_SUDO_STATUS:-0}"
+case " $* " in
+  *" -S "*)
+    IFS= read -r piped_password || piped_password=
+    printf 'sudo-password %s\n' "$piped_password" >>"$MOCK_LOG"
+    exit "${TEST_SUDO_PASSWORD_STATUS:-0}"
+    ;;
+  *) exit "${TEST_SUDO_STATUS:-0}" ;;
+esac
 EOF
 
   make_mock git << 'EOF'
@@ -163,6 +170,8 @@ run_bootstrap() {
     TEST_ID_UID="${TEST_ID_UID:-1000}" \
     TEST_XCODE_STATUS="${TEST_XCODE_STATUS:-0}" \
     TEST_SUDO_STATUS="${TEST_SUDO_STATUS:-0}" \
+    TEST_SUDO_PASSWORD_STATUS="${TEST_SUDO_PASSWORD_STATUS:-0}" \
+    DOTFILES_TTY_DEVICE="${TEST_TTY_DEVICE:-/dev/tty}" \
     TEST_SOURCE_CURL_STATUS="${TEST_SOURCE_CURL_STATUS:-0}" \
     TEST_UV_CURL_STATUS="${TEST_UV_CURL_STATUS:-0}" \
     TEST_SOURCE_TAR_STATUS="${TEST_SOURCE_TAR_STATUS:-0}" \


### PR DESCRIPTION
## Why

`test bootstrap` fails on master since ec68a8a ([master run](https://github.com/shmileee/dotfiles/actions/runs/33965088024), also inherited by every PR, e.g. #105): the new sudo password prompt reads `/dev/tty` unconditionally, and bats test 21 still asserts the removed `--ask-become-pass` flow. Beyond the test, any headless run (no controlling terminal) dies on the unguarded `stty` under `set -eu` with a raw stty error instead of an actionable message.

## What

- **setup.sh / reconcile.sh**: resolve the prompt terminal via `DOTFILES_TTY_DEVICE` (defaults to `/dev/tty`; same testability-override pattern as `DOTFILES_OS_RELEASE_FILE` / `DOTFILES_CA_BUNDLE_FILE`), probe that the device can actually be opened and fail with a clear message when it can't, and make the cosmetic `stty` echo toggling best-effort so it never kills the script.
- **test-helper.bash**: the sudo mock now distinguishes the `-n` probe from `-S` password validation, records the piped password in the command log, and `run_bootstrap` passes the tty override through.
- **bootstrap.bats**: tests 20/21 rewritten to the new contract, plus two new failure-path tests (rejected password, no terminal available).

## Verification

`bats tests/bootstrap` → 26/26 pass locally (was 23/24 with test 21 failing). All pre-commit hooks (shellcheck, shfmt, gitleaks, …) pass.

Once merged, #105 can be rebased/rerun to go green.