### PR TITLE
fix(ansible): restore Galaxy collections with bounded retries

### DIFF
--- a/bootstrap/ansible/requirements.yml
+++ b/bootstrap/ansible/requirements.yml
@@ -2,13 +2,7 @@
 collections:
   - name: ansible.posix
     version: "2.2.2"
-    source: https://github.com/ansible-collections/ansible.posix.git
-    type: git
   - name: community.general
     version: "13.3.0"
-    source: https://github.com/ansible-collections/community.general.git
-    type: git
   - name: community.library_inventory_filtering_v1
     version: "1.1.5"
-    source: https://github.com/ansible-collections/community.library_inventory_filtering.git
-    type: git

--- a/bootstrap/reconcile.sh
+++ b/bootstrap/reconcile.sh
@@ -84,9 +84,24 @@ printf '[dotfiles] Synchronizing locked reconciliation runtime\n'
 uv sync --project "$project" --locked --managed-python
 
 printf '[dotfiles] Installing exactly pinned Ansible collections\n'
-run_in_runtime ansible-galaxy collection install \
-  --collections-path "$collections" \
-  --requirements-file "$collection_requirements"
+galaxy_retry_delay=${DOTFILES_GALAXY_RETRY_DELAY:-10}
+galaxy_attempt=1
+while :; do
+  galaxy_status=0
+  run_in_runtime ansible-galaxy collection install \
+    --collections-path "$collections" \
+    --requirements-file "$collection_requirements" || galaxy_status=$?
+  if [ "$galaxy_status" -eq 0 ]; then
+    break
+  fi
+  if [ "$galaxy_attempt" -ge 3 ]; then
+    printf '[dotfiles] Ansible Galaxy could not install the pinned collections.\n' >&2
+    exit "$galaxy_status"
+  fi
+  printf '[dotfiles] Ansible Galaxy attempt %s failed; retrying in %ss\n' "$galaxy_attempt" "$galaxy_retry_delay"
+  sleep "$galaxy_retry_delay"
+  galaxy_attempt=$((galaxy_attempt + 1))
+done
 
 printf '[dotfiles] Validating locked runtime identity\n'
 run_in_runtime python "$repository_root/bootstrap/validate_runtime.py" \

--- a/bootstrap/setup.sh
+++ b/bootstrap/setup.sh
@@ -342,12 +342,22 @@ prepare_ansible() {
   fi
 
   phase 'Installing exactly pinned Ansible collections'
-  galaxy_status=0
-  if [ "$insecure_bootstrap_transport" = true ]; then
-    install_bootstrap_collections --ignore-certs || galaxy_status=$?
-  else
-    install_bootstrap_collections || galaxy_status=$?
-  fi
+  galaxy_retry_delay=${DOTFILES_GALAXY_RETRY_DELAY:-10}
+  galaxy_attempt=1
+  while :; do
+    galaxy_status=0
+    if [ "$insecure_bootstrap_transport" = true ]; then
+      install_bootstrap_collections --ignore-certs || galaxy_status=$?
+    else
+      install_bootstrap_collections || galaxy_status=$?
+    fi
+    if [ "$galaxy_status" -eq 0 ] || [ "$galaxy_attempt" -ge 3 ]; then
+      break
+    fi
+    phase "Ansible Galaxy attempt $galaxy_attempt failed; retrying in ${galaxy_retry_delay}s"
+    sleep "$galaxy_retry_delay"
+    galaxy_attempt=$((galaxy_attempt + 1))
+  done
   if [ "$galaxy_status" -eq 0 ]; then
     :
   else

--- a/tests/bootstrap/bootstrap.bats
+++ b/tests/bootstrap/bootstrap.bats
@@ -251,9 +251,12 @@ teardown() {
 
   TEST_SYNC_STATUS=0
   TEST_GALAXY_STATUS=42
+  : > "$command_log"
   run_bootstrap
   [ "$status" -eq 42 ]
   [[ $output == *"Ansible Galaxy"* ]]
+  [[ $output == *"retrying"* ]]
+  [ "$(grep -c 'ansible-galaxy collection install' "$command_log")" -eq 3 ]
 
   TEST_GALAXY_STATUS=0
   TEST_ANSIBLE_STATUS=43

--- a/tests/bootstrap/test-helper.bash
+++ b/tests/bootstrap/test-helper.bash
@@ -28,7 +28,7 @@ setup_bootstrap_test() {
   : > "$command_log"
   write_os_release ubuntu current
 
-  for command_name in cat chmod cmp cp dirname mkdir rm sed stat touch; do
+  for command_name in cat chmod cmp cp dirname mkdir rm sed sleep stat touch; do
     ln -s "$(command -v "$command_name")" "$base_bin/$command_name"
   done
 
@@ -176,6 +176,7 @@ run_bootstrap() {
     TEST_UV_VERSION_STATUS="${TEST_UV_VERSION_STATUS:-0}" \
     TEST_SYNC_STATUS="${TEST_SYNC_STATUS:-0}" \
     TEST_GALAXY_STATUS="${TEST_GALAXY_STATUS:-0}" \
+    DOTFILES_GALAXY_RETRY_DELAY=0 \
     TEST_RUNTIME_VALIDATION_STATUS="${TEST_RUNTIME_VALIDATION_STATUS:-0}" \
     TEST_ANSIBLE_STATUS="${TEST_ANSIBLE_STATUS:-0}" \
     "$bootstrap_shell" "$setup_under_test" "$@"

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -35,11 +35,19 @@ WORKDIR /source
 # system bundle, so only that pre-Ansible call ignores certificates. The first
 # Ansible task installs and updates ca-certificates.
 RUN uv sync --project bootstrap --locked --managed-python && \
-    ANSIBLE_COLLECTIONS_PATH=/tmp/ansible-collections \
-    uv run --project bootstrap --locked --managed-python \
-      ansible-galaxy collection install --ignore-certs \
-      --collections-path /tmp/ansible-collections \
-      --requirements-file bootstrap/ansible/requirements.yml
+    for galaxy_attempt in 1 2 3; do \
+      if ANSIBLE_COLLECTIONS_PATH=/tmp/ansible-collections \
+        uv run --project bootstrap --locked --managed-python \
+          ansible-galaxy collection install --ignore-certs \
+          --collections-path /tmp/ansible-collections \
+          --requirements-file bootstrap/ansible/requirements.yml; then \
+        break; \
+      elif [ "$galaxy_attempt" -ge 3 ]; then \
+        exit 1; \
+      else \
+        sleep 10; \
+      fi; \
+    done
 
 RUN ANSIBLE_CONFIG=bootstrap/ansible/ansible.cfg \
     ANSIBLE_COLLECTIONS_PATH=/tmp/ansible-collections \


### PR DESCRIPTION
## Why

The docker pipeline fails on master since cbc59e7 ([run 33967169137](https://github.com/shmileee/dotfiles/actions/runs/33967169137)): switching `requirements.yml` to `type: git` sources means `ansible-galaxy` needs a **git executable**, but bootstrap installs collections *before* the playbook ever installs git. The integration image caught a real product bug — it deliberately asserts git is absent to prove bootstrap works on pristine machines, and that guarantee is now broken (a fresh Ubuntu box would fail the same way, not just CI).

## What

- **requirements.yml**: revert to pinned Galaxy sources (pre-cbc59e7), keeping the exact same version pins.
- **setup.sh / reconcile.sh**: absorb the original problem (transient Galaxy 504s) instead — the collection install retries up to 3 attempts with a delay between them (`DOTFILES_GALAXY_RETRY_DELAY`, default 10s, same env-override pattern as the other `DOTFILES_*` knobs). Final exit status and failure message are preserved.
- **tests/integration/Dockerfile**: same 3-attempt retry around the `ansible-galaxy` layer.
- **bats**: the galaxy-failure case now asserts all three attempts happen (`retrying` message + 3 logged invocations) and still propagates the original exit code; the test harness gained `sleep` in its restricted PATH and sets the retry delay to 0.

## Verification

- `bats tests/bootstrap` → 25/25 pass locally.
- Real `ansible-galaxy collection install` against galaxy.ansible.com with an isolated `ANSIBLE_COLLECTIONS_PATH` → all 3 pinned collections download and install successfully.
- `dash -n` on both shell scripts; shellcheck/shfmt/ansible-lint pre-commit hooks pass.