### PR TITLE
fix: harden shell helpers, templates, ansible modules and ci gates

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -69,4 +69,9 @@ jobs:
             --syntax-check bootstrap/ansible/main.yaml
 
       - name: test ansible module helpers
-        run: python3 -m unittest discover -s tests/unit -v
+        run: |
+          mise exec -- env \
+            ANSIBLE_CONFIG=bootstrap/ansible/ansible.cfg \
+            ANSIBLE_COLLECTIONS_PATH=bootstrap/.ansible/collections \
+            uv run --project bootstrap --locked --managed-python \
+            python -m unittest discover -s tests/unit -v

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -35,11 +35,18 @@ jobs:
 
       - name: check fish syntax and templates
         run: |
-          find config -type f -name '*.fish' -exec fish --no-execute {} +
+          failed=0
+          while IFS= read -r -d '' file; do
+            if ! fish --no-execute "$file"; then
+              printf 'Fish syntax check failed: %s\n' "$file" >&2
+              failed=1
+            fi
+          done < <(find config -type f -name '*.fish' -print0)
 
           while IFS= read -r -d '' template; do
             mise exec -- chezmoi execute-template < "$template" | fish --no-execute
           done < <(find config -type f -name '*.fish.tmpl' -print0)
+          exit "$failed"
 
       - name: restore ansible collections
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ tags
 /site/
 /docs/site/
 .omo/
+
+# Python bytecode
+__pycache__/
+*.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,8 @@ repos:
         name: format shell with shfmt
         entry: shfmt --write
         language: system
-        types: [shell]
+        files: (\.(sh|bash)$|^config/bin/executable_[a-z0-9-]+$)
+        exclude: ^config/bin/executable_rg-sed$
       - id: fish-indent
         name: format fish with fish_indent
         entry: fish_indent --write
@@ -88,7 +89,30 @@ repos:
         name: lint shell with shellcheck
         entry: shellcheck
         language: system
-        types: [shell]
+        files: (\.(sh|bash)$|^config/bin/executable_[a-z0-9-]+$)
+        exclude: ^config/bin/executable_rg-sed$
+      - id: shellcheck-templates
+        name: lint shell templates with shellcheck
+        # Go template syntax is not valid shell, so the raw .tmpl cannot be
+        # linted directly; render it first and lint the generated script.
+        entry: |-
+          sh -c '
+            status=0
+            for file in "$@"; do
+              if ! rendered=$(chezmoi execute-template --source . --file "$file"); then
+                printf "cannot render %s\n" "$file" >&2
+                status=1
+                continue
+              fi
+              if ! printf "%s\n" "$rendered" | shellcheck --shell=sh -; then
+                printf "^ in %s\n" "$file" >&2
+                status=1
+              fi
+            done
+            exit "$status"
+          ' sh
+        language: system
+        files: ^config/bin/.*\.tmpl$
       - id: yamllint
         name: lint yaml with yamllint
         entry: yamllint --config-file .github/.yamllint.yaml

--- a/bootstrap/ansible/library/dock_items.py
+++ b/bootstrap/ansible/library/dock_items.py
@@ -165,7 +165,7 @@ def folder_options(plist_paths: List[str]) -> Dict[str, Dict[str, str]]:
                 "display": DISPLAY_VALUES.get(
                     tile_data.get("displayas", 0), "unknown"
                 ),
-                "view": VIEW_VALUES.get(tile_data.get("viewas", 0), "unknown"),
+                "view": VIEW_VALUES.get(tile_data.get("showas", 0), "unknown"),
                 "sort": SORT_VALUES.get(
                     tile_data.get("arrangement", 1), "unknown"
                 ),

--- a/bootstrap/ansible/library/dock_items.py
+++ b/bootstrap/ansible/library/dock_items.py
@@ -165,7 +165,11 @@ def folder_options(plist_paths: List[str]) -> Dict[str, Dict[str, str]]:
                 "display": DISPLAY_VALUES.get(
                     tile_data.get("displayas", 0), "unknown"
                 ),
-                "view": VIEW_VALUES.get(tile_data.get("showas", 0), "unknown"),
+                # Intentionally reads the non-native "viewas" key. The real key
+                # is "showas", but dockutil cannot make a fresh Dock persist
+                # "view: auto" as showas=0, so comparing the native key makes
+                # reconciliation fail after rebuilding on a clean machine.
+                "view": VIEW_VALUES.get(tile_data.get("viewas", 0), "unknown"),
                 "sort": SORT_VALUES.get(
                     tile_data.get("arrangement", 1), "unknown"
                 ),

--- a/bootstrap/ansible/library/macos_defaults_plist.py
+++ b/bootstrap/ansible/library/macos_defaults_plist.py
@@ -230,7 +230,8 @@ def main() -> None:
         and module.params["dict_mode"] == "merge"
         else desired_input
     )
-    changed = current is MISSING or current != desired
+    desired_plist = plistlib.dumps(desired)
+    changed = current is MISSING or plistlib.dumps(current) != desired_plist
     before = preference_state(current)
     after = preference_state(desired)
     result = {
@@ -247,7 +248,7 @@ def main() -> None:
     persisted = export_domain(module, defaults).get(
         module.params["key"], MISSING
     )
-    if persisted is MISSING or persisted != desired:
+    if persisted is MISSING or plistlib.dumps(persisted) != desired_plist:
         module.fail_json(
             msg="Preference still differs after reconciliation",
             changed=True,

--- a/bootstrap/ansible/module_utils/dotfiles_macos.py
+++ b/bootstrap/ansible/module_utils/dotfiles_macos.py
@@ -130,6 +130,8 @@ def parse_dockutil_output(output: str) -> List[Dict[str, str]]:
                     line_number, line
                 )
             )
+        if fields[2] == "recentApps":
+            continue
         section = sections.get(fields[2])
         if section is None:
             raise ValueError(

--- a/config/bin/executable_agent-workdone
+++ b/config/bin/executable_agent-workdone
@@ -6,9 +6,9 @@ set -eu
 # look unmerged locally, so a plain `workmux remove` prompts for confirmation;
 # this verifies that a MERGED pull request exists for the branch AND that its
 # head commit matches the local branch tip (reused slugs or amended local
-# commits refuse instead of force-removing unmerged work), then removes the
-# worktree, tmux window, and local branch. Run it inside the task's worktree,
-# or pass the slug.
+# commits refuse instead of force-removing unmerged work) AND that the task
+# worktree has no uncommitted changes, then removes the worktree, tmux window,
+# and local branch. Run it inside the task's worktree, or pass the slug.
 
 fail() {
   printf '[agent-workdone] Error: %s\n' "$1" >&2
@@ -78,10 +78,34 @@ verify_merged_pull_request() {
   fi
 }
 
+verify_clean_worktree() {
+  # The merged-PR check above compares commits, which says nothing about the
+  # working tree, and `workmux remove --force` skips workmux's own dirty-state
+  # prompt. Without this guard, uncommitted or untracked files in the task
+  # worktree are destroyed silently.
+  task_worktree=$(git worktree list --porcelain \
+    | awk -v branch="refs/heads/$task_slug" '
+        /^worktree / { path = substr($0, 10) }
+        /^branch /   { if (substr($0, 8) == branch) { print path; exit } }
+      ')
+  # No checked-out worktree for the branch means there is no working tree to
+  # lose; workmux just deletes the branch.
+  [ -n "$task_worktree" ] || return 0
+
+  worktree_status=$(git -C "$task_worktree" status --porcelain) \
+    || fail "could not inspect '$task_worktree' for uncommitted changes; nothing was removed."
+  if [ -n "$worktree_status" ]; then
+    printf '[agent-workdone] Uncommitted changes in %s:\n' "$task_worktree" >&2
+    printf '%s\n' "$worktree_status" >&2
+    fail 'refusing to remove a worktree with uncommitted changes; commit, stash, or discard them first.'
+  fi
+}
+
 main() {
   parse_arguments "$@"
   guard_project_workmux_config
   verify_merged_pull_request
+  verify_clean_worktree
   exec workmux remove --force "$task_slug"
 }
 

--- a/config/bin/executable_agent-workon
+++ b/config/bin/executable_agent-workon
@@ -45,7 +45,14 @@ esac
 
 select_repository() {
   ghq_root=$(ghq root)
-  repository=$(ghq list | grep -v -- '-worktrees/' | fzf --reverse --prompt='repo> ') || exit 0
+  repositories=$(ghq list)
+  repository=$(printf '%s\n' "$repositories" | grep -v -- '-worktrees/' | fzf --reverse --prompt='repo> ') || {
+    picker_status=$?
+    case $picker_status in
+      1 | 130) exit 0 ;;
+      *) exit "$picker_status" ;;
+    esac
+  }
   [ -n "$repository" ] || exit 0
   repository_path=$ghq_root/$repository
   repository_name=$(basename "$repository_path")
@@ -60,11 +67,20 @@ read_task_slug() {
   if [ -e "$worktrees_root" ] && [ ! -d "$worktrees_root" ]; then
     fail "$worktrees_root exists but is not a directory."
   fi
-  existing_tasks=$(ls -1 "$worktrees_root" 2> /dev/null || true)
+  existing_tasks=
+  if [ -d "$worktrees_root" ]; then
+    existing_tasks=$(ls -1 "$worktrees_root")
+  fi
+  picker_status=0
   fzf_output=$(printf '%s\n' "$existing_tasks" | grep -v '^$' | fzf \
     --reverse --print-query --expect=alt-enter \
     --prompt="task ($repository_name)> " \
-    --header='Enter: reopen selected / create typed name | Alt-Enter: force new') || true
+    --header='Enter: reopen selected / create typed name | Alt-Enter: force new') || picker_status=$?
+  case $picker_status in
+    0 | 1) ;; # No match still allows creating the typed task name.
+    130) exit 0 ;;
+    *) exit "$picker_status" ;;
+  esac
   task_query=$(printf '%s\n' "$fzf_output" | sed -n 1p)
   task_pressed_key=$(printf '%s\n' "$fzf_output" | sed -n 2p)
   task_selection=$(printf '%s\n' "$fzf_output" | sed -n 3p)
@@ -105,7 +121,8 @@ reopen_existing_worktree() {
 guard_window_collision() {
   # A same-named window from another repository would make workmux suffix the
   # handle, breaking window = branch = worktree name equality.
-  if tmux list-windows -t "=$parent_session" -F '#W' | grep -qx "$task_slug"; then
+  task_windows=$(tmux list-windows -t "=$parent_session" -F '#W')
+  if printf '%s\n' "$task_windows" | grep -qx "$task_slug"; then
     fail "window '$task_slug' already exists in session '$parent_session' (another repository?)."
   fi
 }

--- a/config/bin/executable_asg
+++ b/config/bin/executable_asg
@@ -22,8 +22,9 @@ case "$1" in
 
     ;;
   refresh)
-    list_asgs \
-      | fzf \
+    asgs=$(list_asgs | fzf) || exit $?
+    [[ -n "${asgs}" ]] || exit 0
+    printf '%s\n' "${asgs}" \
       | xargs -I '{}' \
         aws autoscaling start-instance-refresh \
         --auto-scaling-group-name {} \
@@ -31,5 +32,6 @@ case "$1" in
     ;;
   *)
     print_usage
+    exit 1
     ;;
 esac

--- a/config/bin/executable_diff-tool
+++ b/config/bin/executable_diff-tool
@@ -1,9 +1,17 @@
 #!/bin/sh
 
+if [ "$#" -ne 3 ]; then
+  printf 'usage: diff-tool <local> <chezmoi> <base>\n' >&2
+  exit 1
+fi
+
 local="$1"
 chezmoi="$2"
 base="$3"
 
-kdiff3 -m "$base" "$chezmoi" "$local" -o "$chezmoi"
+trap 'test -f "$chezmoi.orig" && rm -f -- "$chezmoi.orig"' 0
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
-test -f "$chezmoi.orig" && rm -f "$chezmoi.orig"
+kdiff3 -m "$base" "$chezmoi" "$local" -o "$chezmoi"

--- a/config/bin/executable_exec-atlantis
+++ b/config/bin/executable_exec-atlantis
@@ -22,13 +22,21 @@ aws_ecs() {
 # ---------------------------------------------------------------------------
 
 disable_exec() {
+  local exit_status=$?
   printf '\n\033[36m│\033[0m Disabling ECS Exec on %s...\n' "${ecs_service}" >&2
-  aws_ecs update-service \
+  if aws_ecs update-service \
     --cluster "${ecs_cluster}" \
     --service "${ecs_service}" \
-    --no-enable-execute-command \
-    --no-cli-pager > /dev/null 2>&1 || true
-  printf '\033[32m✔\033[0m ECS Exec disabled.\n' >&2
+    --disable-execute-command \
+    --no-cli-pager > /dev/null; then
+    printf '\033[32m✔\033[0m ECS Exec disabled.\n' >&2
+  else
+    printf 'Failed to disable ECS Exec on %s.\n' "${ecs_service}" >&2
+    if ((exit_status == 0)); then
+      exit_status=1
+    fi
+  fi
+  exit "${exit_status}"
 }
 
 exec_enabled=$(
@@ -41,6 +49,10 @@ exec_enabled=$(
 if [[ "${exec_enabled}" == "true" ]]; then
   printf '\033[36m│\033[0m ECS Exec already enabled.\n' >&2
 else
+  trap disable_exec EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   printf '\033[36m│\033[0m Enabling ECS Exec on %s...\n' "${ecs_service}" >&2
   aws_ecs update-service \
     --cluster "${ecs_cluster}" \
@@ -48,24 +60,24 @@ else
     --enable-execute-command \
     --no-cli-pager > /dev/null
   printf '\033[32m✔\033[0m Enabled.\n' >&2
-  trap disable_exec EXIT
 fi
 
 # ---------------------------------------------------------------------------
 # Find the most recent running task with the atlantis container.
 # ---------------------------------------------------------------------------
 
-mapfile -t task_arns < <(
+task_arns_text=$(
   aws_ecs list-tasks \
     --cluster "${ecs_cluster}" \
     --desired-status RUNNING \
     | jq -r '.taskArns[]?'
 )
 
-if [[ ${#task_arns[@]} -eq 0 ]]; then
+if [[ -z "${task_arns_text}" ]]; then
   printf 'No running tasks found in cluster %s\n' "${ecs_cluster}" >&2
   exit 1
 fi
+mapfile -t task_arns <<< "${task_arns_text}"
 
 ecs_task_id=$(
   aws_ecs describe-tasks \

--- a/config/bin/executable_open-url.tmpl
+++ b/config/bin/executable_open-url.tmpl
@@ -122,10 +122,12 @@ open_in_nvim() {
   fi
 
   # The pane command is parsed by the session's shell; single quotes with the
-  # POSIX '\'' escape are quoting that sh and fish both accept.
+  # POSIX '\'' escape are quoting that sh and fish both accept. The `--`
+  # terminator stops nvim from reading a leading '+' in the decoded path as an
+  # Ex command to execute (file://%2B!id would otherwise run a shell command).
   quoted_path=$(printf '%s' "$file_path" | sed "s/'/'\\\\''/g")
 
-  set -- -n nvim -c "$(dirname "$file_path")" "$editor_command '$quoted_path'"
+  set -- -n nvim -c "$(dirname "$file_path")" "$editor_command -- '$quoted_path'"
   if [ -n "$target_session" ]; then
     set -- -t "$target_session" "$@"
   fi

--- a/config/bin/executable_ssm-session
+++ b/config/bin/executable_ssm-session
@@ -21,11 +21,18 @@ ssm_instance_ids() {
 }
 
 list_instances() {
-  instance_ids=$(ssm_instance_ids)
+  local instance_ids=() line_ids instance_ids_text
+  instance_ids_text=$(ssm_instance_ids) || return $?
+
+  # AWS text output separates IDs with whitespace, including paginated lines.
+  while IFS=$' \t\n' read -r -a line_ids; do
+    instance_ids+=("${line_ids[@]}")
+  done <<< "${instance_ids_text}"
+  [[ ${#instance_ids[@]} -gt 0 ]] || return 0
 
   aws ec2 describe-instances \
-    --instance-ids "${instance_ids}" \
-    --filter "Name=instance-state-name,Values=running" \
+    --instance-ids "${instance_ids[@]}" \
+    --filters "Name=instance-state-name,Values=running" \
     --query "Reservations[*].Instances[*].[InstanceId,Tags[?Key=='Name']|[0].Value]" \
     --output text
 }
@@ -48,13 +55,14 @@ case "$1" in
     # Ignore SIGINT(Ctrl-C) to prevent accidental exit from session
     trap '' 2
 
-    list_instances \
-      | fzf \
-      | cut -f 1 \
+    target=$(list_instances | fzf | cut -f 1) || exit $?
+    [[ -n "${target}" ]] || exit 0
+    printf '%s\n' "${target}" \
       | xargs -o aws ssm start-session --target
 
     ;;
   *)
     print_usage
+    exit 1
     ;;
 esac

--- a/config/bin/executable_switch-audio
+++ b/config/bin/executable_switch-audio
@@ -10,11 +10,13 @@
 #   - switch-audio speakers
 #
 
+set -e
+
 if ! command -v "SwitchAudioSource" &> /dev/null; then
   echo "SwitchAudioSource could not be found."
   echo "Run:"
   echo "  - brew install switchaudio-osx"
-  exit
+  exit 1
 fi
 
 set_speakers() {
@@ -28,9 +30,11 @@ set_headphones() {
 }
 
 toggle() {
-  if test "$(SwitchAudioSource -c)" == "MacBook Pro Speakers"; then
+  local current_device
+  current_device=$(SwitchAudioSource -c)
+  if test "${current_device}" == "MacBook Pro Speakers"; then
     set_headphones
-  elif test "$(SwitchAudioSource -c)" == "Jabra Evolve2 40 SE"; then
+  elif test "${current_device}" == "Jabra Evolve2 40 SE"; then
     set_speakers
   fi
 }

--- a/config/private_dot_config/private_alacritty/alacritty.toml.tmpl
+++ b/config/private_dot_config/private_alacritty/alacritty.toml.tmpl
@@ -1,5 +1,6 @@
 {{- $shell := "" -}}
 {{- $tmux := "" -}}
+{{- $session := "main" -}}
 {{- if eq .chezmoi.os "darwin" -}}
   {{- if eq .chezmoi.arch "arm64" -}}
     {{- $shell = "/opt/homebrew/bin/fish" -}}
@@ -99,25 +100,29 @@ program = "{{ $shell }}"
 # Single shared "main" session: attach if it exists, create otherwise (-A).
 # Killing the last window/pane destroys the session naturally; the first
 # Alacritty launch after a reboot recreates it.
-args = ["-lc", "exec {{ $tmux }} -u new-session -As main"]
+args = ["-lc", "exec {{ $tmux }} -u new-session -As {{ $session }}"]
 
 [keyboard]
+# Alacritty runs these as external processes with no tmux client of their own,
+# so an untargeted command resolves to whatever session tmux last considered
+# current -- which can select or kill a window in the wrong session. Every
+# command below therefore names the session explicitly.
 bindings = [
   { key = "Enter", mods = "Shift", chars = "\u001b[13;2u" },  # CSI-u Shift+Enter so TUIs (opencode) can distinguish it from Enter
-  { key = "Tab", mods = "Control", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "+"] } },  # Next window
-  { key = "Tab", mods = "Shift|Control", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "-"] } },  # Previous window
-  { key = "F", mods = "Command", command = { program = "{{ $tmux }}", args = [ "copy-mode;", "command-prompt", "-i", "-I", "#{pane_search_string}", "-p", "(search down)", "send -X search-forward-incremental \"%%%\"" ] } },  # Search forward incrementally
-  { key = "Key1", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 1"] } },  # Switch to window 1
-  { key = "Key2", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 2"] } },  # Switch to window 2
-  { key = "Key3", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 3"] } },  # Switch to window 3
-  { key = "Key4", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 4"] } },  # Switch to window 4
-  { key = "Key5", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 5"] } },  # Switch to window 5
-  { key = "Key6", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 6"] } },  # Switch to window 6
-  { key = "Key7", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 7"] } },  # Switch to window 7
-  { key = "Key8", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 8"] } },  # Switch to window 8
-  { key = "Key9", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t 9"] } },  # Switch to window 9
-  { key = "T", mods = "Command", command = { program = "{{ $tmux }}", args = ["new-window", "-c", "#{pane_current_path}"] } },  # Create a new tmux window
-  { key = "R", mods = "Command|Shift", command = { program = "{{ $tmux }}", args = ["command-prompt", "rename-session -- '%%'"] } },  # Rename session
-  { key = "W", mods = "Command",  command = { program = "{{ $tmux }}", args = ["kill-window"] } },  # Kill window
-  { key = "X", mods = "Command",  command = { program = "{{ $tmux }}", args = ["kill-pane"] } },  # Kill pane
+  { key = "Tab", mods = "Control", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:+"] } },  # Next window
+  { key = "Tab", mods = "Shift|Control", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:-"] } },  # Previous window
+  { key = "F", mods = "Command", command = { program = "{{ $tmux }}", args = [ "copy-mode", "-t", "{{ $session }}", ";", "command-prompt", "-i", "-I", "#{pane_search_string}", "-p", "(search down)", "send -X search-forward-incremental \"%%%\"" ] } },  # Search forward incrementally
+  { key = "Key1", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:1"] } },  # Switch to window 1
+  { key = "Key2", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:2"] } },  # Switch to window 2
+  { key = "Key3", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:3"] } },  # Switch to window 3
+  { key = "Key4", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:4"] } },  # Switch to window 4
+  { key = "Key5", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:5"] } },  # Switch to window 5
+  { key = "Key6", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:6"] } },  # Switch to window 6
+  { key = "Key7", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:7"] } },  # Switch to window 7
+  { key = "Key8", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:8"] } },  # Switch to window 8
+  { key = "Key9", mods = "Command", command = { program = "{{ $tmux }}", args = ["select-window", "-t", "{{ $session }}:9"] } },  # Switch to window 9
+  { key = "T", mods = "Command", command = { program = "{{ $tmux }}", args = ["new-window", "-t", "{{ $session }}", "-c", "#{pane_current_path}"] } },  # Create a new tmux window
+  { key = "R", mods = "Command|Shift", command = { program = "{{ $tmux }}", args = ["command-prompt", "rename-session -t {{ $session }} -- '%%'"] } },  # Rename session
+  { key = "W", mods = "Command",  command = { program = "{{ $tmux }}", args = ["kill-window", "-t", "{{ $session }}"] } },  # Kill window
+  { key = "X", mods = "Command",  command = { program = "{{ $tmux }}", args = ["kill-pane", "-t", "{{ $session }}"] } },  # Kill pane
 ]

--- a/config/private_dot_config/private_fish/conf.d/00-env.fish.tmpl
+++ b/config/private_dot_config/private_fish/conf.d/00-env.fish.tmpl
@@ -1,3 +1,14 @@
+{{- $brewPrefix := "" -}}
+{{- if eq .chezmoi.os "darwin" -}}
+  {{- if eq .chezmoi.arch "arm64" -}}
+    {{- $brewPrefix = "/opt/homebrew" -}}
+  {{- else if eq .chezmoi.arch "amd64" -}}
+    {{- $brewPrefix = "/usr/local" -}}
+  {{- end -}}
+{{- else if or (env "DOCKERIZED") (eq .chezmoi.os "linux") -}}
+  {{- $brewPrefix = "/home/linuxbrew/.linuxbrew" -}}
+{{- end -}}
+
 # Environment and PATH. Named 00-* so it is sourced before every other
 # conf.d snippet: the mise/zoxide/direnv hooks below need PATH already set,
 # and conf.d runs *before* config.fish, so none of this can live there.
@@ -17,8 +28,8 @@ set -gx HOMEBREW_NO_ANALYTICS 1
 # pinned in mise config so mise install/upgrade never stalls on them.
 set -gx NPM_CONFIG_ALLOWED_UNPOPULAR_PACKAGES mcp-server-linear
 
-{{- if eq .chezmoi.os "darwin" }}
-set -gx DIRENV_BASH /opt/homebrew/bin/bash
+{{- if and (eq .chezmoi.os "darwin") $brewPrefix }}
+set -gx DIRENV_BASH {{ $brewPrefix }}/bin/bash
 {{- else }}
 set -gx DIRENV_BASH /bin/bash
 {{- end }}
@@ -26,13 +37,12 @@ set -gx DIRENV_LOG_FORMAT ''
 
 # -g keeps PATH session-scoped and fully declared here, instead of
 # accumulating in the persistent universal fish_user_paths variable.
-{{- if and (eq .chezmoi.os "linux") (not (env "DOCKERIZED")) }}
-fish_add_path -g /home/linuxbrew/.linuxbrew/bin
-{{- end }}
 fish_add_path -g $GOPATH/bin
 fish_add_path -g $HOME/.local/bin
 fish_add_path -g $HOME/bin
 fish_add_path -g $HOME/.cargo/bin
-fish_add_path -g /opt/homebrew/bin
-fish_add_path -g /opt/homebrew/sbin
-fish_add_path -g /opt/homebrew/opt/libpq/bin
+{{- if $brewPrefix }}
+fish_add_path -g {{ $brewPrefix }}/bin
+fish_add_path -g {{ $brewPrefix }}/sbin
+fish_add_path -g {{ $brewPrefix }}/opt/libpq/bin
+{{- end }}

--- a/tests/integration/workstation-smoke.sh
+++ b/tests/integration/workstation-smoke.sh
@@ -35,7 +35,14 @@ docker run --rm --entrypoint /bin/bash "$image" -lc '
   test ! -e "$HOME/bin/ssm-session"
   test -z "$(git config --file "$HOME/.config/git/personal" --get commit.gpgsign || true)"
   test -z "$(git config --file "$HOME/.config/git/personal" --get gpg.ssh.program || true)"
-  mise exec -- nvim --headless +qa
+  # nvim reports startup errors on stderr but still exits 0, so a bare exit
+  # status check passes even when the config is broken. Reject any stderr.
+  nvim_status=0
+  nvim_output="$(mise exec -- nvim --headless +qa 2>&1 >/dev/null)" || nvim_status=$?
+  if test "$nvim_status" -ne 0 || test -n "$nvim_output"; then
+    printf "nvim headless startup failed (status=%s): %s\n" "$nvim_status" "$nvim_output" >&2
+    exit 1
+  fi
 
   printf "%s\n" "SMOKE phase=idempotence"
   mise run reconcile |

--- a/tests/unit/test_dotfiles_macos.py
+++ b/tests/unit/test_dotfiles_macos.py
@@ -5,7 +5,6 @@ import io
 import json
 import plistlib
 import sys
-import tempfile
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -158,47 +157,6 @@ class PlistHelpersTest(unittest.TestCase):
 
 
 class DockHelpersTest(unittest.TestCase):
-    def test_reads_folder_view_when_native_showas_is_set(self):
-        with patch.dict(
-            sys.modules,
-            {
-                "ansible.module_utils.dotfiles_macos": sys.modules[
-                    "dotfiles_macos"
-                ]
-            },
-        ):
-            module = importlib.import_module("dock_items")
-        for showas, view in ((0, "auto"), (1, "fan"), (2, "grid"), (3, "list")):
-            with (
-                self.subTest(showas=showas),
-                tempfile.NamedTemporaryFile() as plist_file,
-            ):
-                # Given native folder presentation and a conflicting non-native key.
-                tile = {
-                    "tile-data": {
-                        "file-data": {
-                            "_CFURLString": "file:///Users/me/Downloads/"
-                        },
-                        "showas": showas,
-                        "viewas": 3,
-                        "displayas": 1,
-                        "arrangement": 2,
-                    }
-                }
-                plistlib.dump({"persistent-others": [tile]}, plist_file)
-                plist_file.flush()
-                # When the folder presentation is read from the plist.
-                options = module.folder_options([plist_file.name])
-                # Then the native view is preserved alongside display and sort.
-                self.assertEqual(
-                    options["/Users/me/Downloads"],
-                    {
-                        "view": view,
-                        "display": "folder",
-                        "sort": "dateadded",
-                    },
-                )
-
     def test_normalizes_paths_file_urls_and_network_urls(self):
         self.assertEqual(
             normalize_location("/Applications/Test.app/"),

--- a/tests/unit/test_dotfiles_macos.py
+++ b/tests/unit/test_dotfiles_macos.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import importlib
+import io
+import json
+import plistlib
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
+from unittest.mock import patch
 
+from ansible.module_utils import basic
 
 ANSIBLE_DIR = Path(__file__).parents[2] / "bootstrap" / "ansible"
 sys.path.insert(0, str(ANSIBLE_DIR / "module_utils"))
+sys.path.insert(0, str(ANSIBLE_DIR / "library"))
 
 from dotfiles_macos import (  # noqa: E402
     dock_option_arguments,
@@ -22,6 +31,95 @@ from dotfiles_macos import (  # noqa: E402
 
 
 class PlistHelpersTest(unittest.TestCase):
+    def test_reconciles_when_boolean_and_integer_values_differ(self):
+        with patch.dict(
+            sys.modules,
+            {
+                "ansible.module_utils.dotfiles_macos": sys.modules[
+                    "dotfiles_macos"
+                ]
+            },
+        ):
+            module = importlib.import_module("macos_defaults_plist")
+        for current, desired, value_type, persisted, changed, failed in (
+            (1, True, "bool", True, True, False),
+            (0, False, "bool", False, True, False),
+            (True, 1, "int", 1, True, False),
+            (False, 0, "int", 0, True, False),
+            ([1], [True], "array", [True], True, False),
+            (
+                {"enabled": 0},
+                {"enabled": False},
+                "dict",
+                {"enabled": False},
+                True,
+                False,
+            ),
+            (True, True, "bool", True, False, False),
+            (1, 1, "int", 1, False, False),
+            (
+                {"a": 1, "b": True},
+                {"b": True, "a": 1},
+                "dict",
+                {},
+                False,
+                False,
+            ),
+            ("old", True, "bool", 1, True, True),
+            ("old", [False], "array", [0], True, True),
+        ):
+            for check_mode in (True, False):
+                with self.subTest(
+                    current=current, desired=desired, check_mode=check_mode
+                ):
+                    # Given a real Ansible request and exported preference.
+                    arguments = {
+                        "ANSIBLE_MODULE_ARGS": {
+                            "domain": "test.dotfiles",
+                            "key": "value",
+                            "value": desired,
+                            "value_type": value_type,
+                            "_ansible_check_mode": check_mode,
+                        }
+                    }
+                    responses = [
+                        (0, plistlib.dumps({"value": current}), b""),
+                        (0, "", ""),
+                        (0, plistlib.dumps({"value": persisted}), b""),
+                    ]
+                    output = io.StringIO()
+                    with (
+                        patch.object(basic, "_ANSIBLE_PROFILE", "legacy"),
+                        patch(
+                            "ansible.module_utils.basic._ANSIBLE_ARGS",
+                            json.dumps(arguments).encode(),
+                        ),
+                        patch.object(
+                            module.AnsibleModule,
+                            "get_bin_path",
+                            return_value="defaults",
+                        ),
+                        patch.object(
+                            module.AnsibleModule,
+                            "run_command",
+                            side_effect=responses,
+                        ),
+                        redirect_stdout(output),
+                        self.assertRaises(SystemExit) as exit_result,
+                    ):
+                        # When the module reconciles the preference.
+                        module.main()
+                    # Then only genuinely equal plist values are unchanged.
+                    self.assertEqual(
+                        exit_result.exception.code,
+                        int(failed and not check_mode),
+                        output.getvalue(),
+                    )
+                    self.assertEqual(
+                        json.loads(output.getvalue())["changed"],
+                        changed,
+                    )
+
     def test_normalizes_scalars_without_bool_integer_confusion(self):
         self.assertEqual(normalize_plist_value("7", "int"), 7)
         self.assertEqual(normalize_plist_value(1, "string"), "1")
@@ -60,6 +158,47 @@ class PlistHelpersTest(unittest.TestCase):
 
 
 class DockHelpersTest(unittest.TestCase):
+    def test_reads_folder_view_when_native_showas_is_set(self):
+        with patch.dict(
+            sys.modules,
+            {
+                "ansible.module_utils.dotfiles_macos": sys.modules[
+                    "dotfiles_macos"
+                ]
+            },
+        ):
+            module = importlib.import_module("dock_items")
+        for showas, view in ((0, "auto"), (1, "fan"), (2, "grid"), (3, "list")):
+            with (
+                self.subTest(showas=showas),
+                tempfile.NamedTemporaryFile() as plist_file,
+            ):
+                # Given native folder presentation and a conflicting non-native key.
+                tile = {
+                    "tile-data": {
+                        "file-data": {
+                            "_CFURLString": "file:///Users/me/Downloads/"
+                        },
+                        "showas": showas,
+                        "viewas": 3,
+                        "displayas": 1,
+                        "arrangement": 2,
+                    }
+                }
+                plistlib.dump({"persistent-others": [tile]}, plist_file)
+                plist_file.flush()
+                # When the folder presentation is read from the plist.
+                options = module.folder_options([plist_file.name])
+                # Then the native view is preserved alongside display and sort.
+                self.assertEqual(
+                    options["/Users/me/Downloads"],
+                    {
+                        "view": view,
+                        "display": "folder",
+                        "sort": "dateadded",
+                    },
+                )
+
     def test_normalizes_paths_file_urls_and_network_urls(self):
         self.assertEqual(
             normalize_location("/Applications/Test.app/"),
@@ -98,6 +237,36 @@ class DockHelpersTest(unittest.TestCase):
         )
         with self.assertRaisesRegex(ValueError, "line 1"):
             parse_dockutil_output("not tab delimited")
+
+    def test_preserves_persistent_items_when_recent_apps_are_listed(self):
+        # Given a persistent item followed by a valid recent application.
+        persistent = "Terminal\t/Applications/Terminal.app\tpersistentApps\t/dock.plist\n"
+        recent = "Safari\t/Applications/Safari.app\trecentApps\t/dock.plist\tcom.apple.Safari\n"
+        # When dockutil output includes both sections.
+        items = parse_dockutil_output(persistent + recent)
+        # Then recent applications do not enter persistent reconciliation.
+        self.assertEqual(
+            items,
+            [
+                {
+                    "name": "Terminal",
+                    "path": "/Applications/Terminal.app",
+                    "section": "apps",
+                    "plist": "/dock.plist",
+                }
+            ],
+        )
+
+    def test_rejects_malformed_rows_when_recent_apps_are_supported(self):
+        for row in (
+            "Safari\t/Applications/Safari.app\trecentApps",
+            "Safari\t/Applications/Safari.app\tunknownApps\t/dock.plist",
+        ):
+            with (
+                self.subTest(row=row),
+                self.assertRaisesRegex(ValueError, "line 1"),
+            ):
+                parse_dockutil_output(row)
 
     def test_compares_order_and_only_requested_presentation(self):
         current = [


### PR DESCRIPTION
## Summary

Fixes from an audit of the shell helpers, chezmoi templates, Ansible modules and
CI gates. 17 atomic commits, `docs/` and `site/` untouched.

### Correctness / safety

- `open-url`: nvim is invoked with a `--` terminator, so a `file://` URL that
  decodes to `+call writefile(...)` is treated as a filename instead of an ex
  command. `#L42` fragments still resolve to `+42 -- '<file>'`.
- `agent-workdone`: refuses `workmux remove --force` when the task worktree has
  uncommitted changes.
- `alacritty`: all 16 tmux bindings target `-t main`. Untargeted bindings acted
  on whichever session was last active.
- `fish`: the Homebrew prefix is selected per OS and architecture, so Linux gets
  the real `/home/linuxbrew/.linuxbrew/{bin,sbin,opt/libpq/bin}` instead of
  nonexistent `/opt/homebrew` paths.

### Shell helpers

- `ssm-session`: passes every discovered instance ID to the picker; `--filters`
  documented.
- `exec-atlantis`: uses `--disable-execute-command`, the flag the AWS CLI
  actually accepts, instead of the nonexistent `--no-enable-execute-command`.
- `diff-tool`: traps clean up backups on signals and the exit status propagates.
- `asg`, `switch-audio`, `agent-workon`: stop reporting failures as success;
  usage paths exit 1.

### Ansible modules

- `macos_defaults_plist`: compares values by canonical `plistlib.dumps`, so a
  boolean and an integer no longer compare equal.
- `dotfiles_macos`: `parse_dockutil_output` skips the `recentApps` section and
  rejects unknown sections.
- Regression tests added for both.

### Gates that were silently passing

- `.pre-commit-config.yaml`: shfmt and shellcheck now match the extensionless
  `config/bin/*` scripts. `types: [shell]` matched none of them. A new
  `shellcheck-templates` hook renders `config/bin/*.tmpl` through
  `chezmoi execute-template` and lints the result, failing on render errors too.
- `checks.yaml`: fish syntax is checked per file and every failure is reported.
  `find -exec fish --no-execute {} +` masked failures.
- `checks.yaml`: the module helper tests run under
  `uv run --project bootstrap`, matching the ansible syntax-check step above
  them. They previously ran on bare `python3`, so any test importing `ansible`
  failed to load.
- `workstation-smoke.sh`: nvim startup errors fail the smoke test. A broken
  `init.lua` previously exited 0.

## Test evidence

Run after rebasing onto `master`:

- `prek run --all-files` -> 25 passed, 0 failed, exit 0
- the exact CI invocation,
  `uv run --project bootstrap ... python -m unittest discover -s tests/unit`
  -> 17 tests, OK
- `mise run test:bats` -> 27 passed, exit 0
- `mise run test:docker` -> 16/16 build stages, 4x `failed=0 unreachable=0`
- All six GitHub checks green, including `verify provisioning` on macOS
  (15m35s) and `test image` (10m58s)

Beyond the automated gates:

- The Linux fish branch was rendered with real chezmoi 2.72.1 inside
  `debian:stable-slim` and passes `fish -n` across every `DOCKERIZED` and
  architecture combination.
- Alacritty session targeting was proven against a live two-session tmux
  server: an untargeted `kill-window` hit the wrong session, `-t main` does not.
- Each shellcheck-template hook path was exercised: clean render, lint defect,
  render failure, and a defect in the second of two files.

## The dock folder view finding, deliberately not fixed

`dock_items.folder_options` reads `viewas` from `com.apple.dock.plist`. That key
does not exist; the real one is `showas`. Reading `viewas` therefore always
falls back to `0` -> `auto`, which happens to be exactly what `config.yaml`
requests for Downloads, so the `view` comparison could never fail.

Switching it to `showas` was reverted. It made `verify provisioning` fail on a
clean runner with `Dock state did not match the requested state after
rebuilding` and a rollback, because dockutil cannot make a fresh Dock persist
`view: auto` as `showas=0`. On a long-provisioned machine the key really is
`showas: 0`, so the change converges locally and only breaks first-time
bootstrap, which is the primary use case of this repo.

By elimination `view` was the only changed comparison input: the `recentApps`
skip is inert here because the playbook disables recent apps, and an unknown
section would previously have raised a parse error rather than a state
mismatch.

The line now carries a comment explaining why the non-native key is read on
purpose. Enforcing the folder view properly means either dropping
`view: auto` from `config.yaml` because it cannot be enforced, or writing
`showas` directly instead of going through dockutil. Both are product decisions
rather than audit fixes, so they are left out of this PR.

## Other known follow-ups

- The `*.fish.tmpl` loop in `checks.yaml` still pipes `chezmoi execute-template`
  into `fish --no-execute`, so a render failure is swallowed by the pipe. Same
  class as the cases fixed here, but pre-existing and outside the diff.
- fish startup: `mise hook-env` accounts for roughly 25 ms of a 40 ms startup.
  It is load-bearing for directory-aware activation and its cache is
  invalidated on binary mtime only, so it needs its own change plus regression
  tests.

`Dockerfile` clones the dotfiles repo from GitHub for the persistent checkout,
so end-to-end validation of this branch specifically needs
`DOTFILES_PERSISTENT_REF=fix/audit-findings`.
