### PR TITLE
fix: surface fish template render failures in CI and stop caching mise activate

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -56,6 +56,9 @@ jobs:
           done < <(find config -type f -name '*.fish.tmpl' -print0)
           exit "$failed"
 
+      - name: test fish functions
+        run: mise run test:fish
+
       - name: restore ansible collections
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -44,7 +44,15 @@ jobs:
           done < <(find config -type f -name '*.fish' -print0)
 
           while IFS= read -r -d '' template; do
-            mise exec -- chezmoi execute-template < "$template" | fish --no-execute
+            if ! rendered="$(mise exec -- chezmoi execute-template < "$template")"; then
+              printf 'Template render failed: %s\n' "$template" >&2
+              failed=1
+              continue
+            fi
+            if ! printf '%s\n' "$rendered" | fish --no-execute; then
+              printf 'Fish template syntax check failed: %s\n' "$template" >&2
+              failed=1
+            fi
           done < <(find config -type f -name '*.fish.tmpl' -print0)
           exit "$failed"
 

--- a/config/private_dot_config/private_fish/conf.d/mise-activate.fish
+++ b/config/private_dot_config/private_fish/conf.d/mise-activate.fish
@@ -1,3 +1,10 @@
 status is-interactive; or return
 
-_source_cached_init mise mise activate fish
+# Never cache `mise activate` output. It bakes in an absolute PATH snapshot
+# plus resolved tool install paths, and _source_cached_init only invalidates on
+# the mise binary's mtime, so a cached copy replays a stale PATH indefinitely
+# and can clobber a newer one. direnv and zoxide emit no such state and stay
+# cached.
+command -q mise; or return
+
+command mise activate fish | source

--- a/config/private_dot_config/private_fish/functions/_source_cached_init.fish
+++ b/config/private_dot_config/private_fish/functions/_source_cached_init.fish
@@ -2,13 +2,34 @@ function _source_cached_init --description "Cache a tool's shell init script and
     set --local tool $argv[1]
     command -q $tool; or return 0
 
-    # Regenerate when the binary is newer than the cache. If a package manager
-    # preserves old mtimes on upgrade, delete the cache file to force it.
-    set --local cache $XDG_CACHE_HOME/fish/$tool-init.fish
-    if not test -f "$cache"; or test (command -v $tool) -nt "$cache"
+    # The cache key must cover every input the generated script depends on: a
+    # stale script is a silent correctness bug, not merely a slow startup.
+    #
+    #   * resolved binary path - direnv bakes its own absolute path into the
+    #     hook it emits, so a relocated binary (Homebrew prefix change,
+    #     reinstall) must invalidate. An mtime check cannot observe a move.
+    #   * fish version - zoxide's init copies fish's internal `cd` and refers
+    #     to $__fish_data_dir, so a fish upgrade must invalidate.
+    #
+    # Both inputs come from builtins, so keying on them costs no subprocess
+    # (~0.05ms). The mtime check then covers in-place binary upgrades.
+    #
+    # Only cache generators whose output is a pure function of these inputs.
+    # `mise activate` is not one: its output embeds the invoking shell's PATH
+    # and mise session state, so it must run live. See conf.d/mise-activate.fish.
+    set --local resolved (command -v $tool)
+    set --local key (string replace --all --regex '[^A-Za-z0-9._-]' _ -- "$resolved-$version")
+    set --local cache $XDG_CACHE_HOME/fish/$tool-init-$key.fish
+
+    if not test -f "$cache"; or test "$resolved" -nt "$cache"
         mkdir -p (dirname $cache)
         if $argv[2..] >$cache.new
             mv $cache.new $cache
+            # Drop variants left by an older binary path or fish version. Runs
+            # only on the cold path; an unmatched glob is a no-op in fish.
+            for stale in $XDG_CACHE_HOME/fish/$tool-init*.fish
+                test "$stale" = "$cache"; or rm -f $stale
+            end
         else
             rm -f $cache.new
             return 1

--- a/config/private_dot_config/private_fish/functions/_source_cached_init.fish
+++ b/config/private_dot_config/private_fish/functions/_source_cached_init.fish
@@ -19,7 +19,11 @@ function _source_cached_init --description "Cache a tool's shell init script and
     # and mise session state, so it must run live. See conf.d/mise-activate.fish.
     set --local resolved (command -v $tool)
     set --local key (string replace --all --regex '[^A-Za-z0-9._-]' _ -- "$resolved-$version")
-    set --local cache $XDG_CACHE_HOME/fish/$tool-init-$key.fish
+    # Normalized because the cleanup loop below compares this path against glob
+    # output, and fish normalizes globs while plain concatenation does not: a
+    # trailing or doubled slash in XDG_CACHE_HOME would otherwise make the two
+    # differ and delete the entry that was just written.
+    set --local cache (path normalize $XDG_CACHE_HOME/fish/$tool-init-$key.fish)
 
     if not test -f "$cache"; or test "$resolved" -nt "$cache"
         mkdir -p (dirname $cache)
@@ -28,7 +32,7 @@ function _source_cached_init --description "Cache a tool's shell init script and
             # Drop variants left by an older binary path or fish version. Runs
             # only on the cold path; an unmatched glob is a no-op in fish.
             for stale in $XDG_CACHE_HOME/fish/$tool-init*.fish
-                test "$stale" = "$cache"; or rm -f $stale
+                test (path normalize $stale) = "$cache"; or rm -f $stale
             end
         else
             rm -f $cache.new

--- a/mise/conf.d/20-bootstrap.toml
+++ b/mise/conf.d/20-bootstrap.toml
@@ -24,6 +24,10 @@ run = "env ANSIBLE_COLLECTIONS_PATH=bootstrap/.ansible/collections uv run --proj
 description = "Run black-box bootstrap behavior tests"
 run = "bats tests/bootstrap"
 
+[tasks."test:fish"]
+description = "Run black-box fish function behavior tests"
+run = "bats tests/fish"
+
 [tasks."test:docker"]
 description = "Run the Ubuntu bootstrap and Ansible integration tests in Docker"
 run = "docker build --file tests/integration/Dockerfile --tag dotfiles-bootstrap-tests ."

--- a/tests/fish/source-cached-init.bats
+++ b/tests/fish/source-cached-init.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+#
+# Behavior tests for _source_cached_init, the fish helper that caches a tool's
+# generated shell init script.
+#
+# The cache is only sound while its key covers every input the generated script
+# depends on. A stale script is a silent correctness bug rather than a slow
+# startup, so each invalidation dimension gets its own test:
+#
+#   * the resolved binary path (direnv bakes its own absolute path into the hook
+#     it emits, and a move cannot be observed through an mtime check)
+#   * the running fish version (zoxide's init copies fish's internal `cd`)
+#   * the binary mtime (in-place upgrades)
+
+setup() {
+  load test-helper
+  setup_fish_test
+}
+
+teardown() {
+  teardown_fish_test
+}
+
+@test "cold start generates the cache and sources it" {
+  run_cached_init
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"generation=1"* ]]
+  assert_generator_calls 1
+  assert_cache_entry_count 1
+}
+
+@test "warm start reuses the cache without invoking the generator" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  run_cached_init
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"generation=1"* ]]
+  assert_generator_calls 1
+  assert_cache_entry_count 1
+}
+
+@test "relocating the binary invalidates the cache even when its mtime is older" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  # Identical content at a different path, deliberately older than the cache so
+  # that the mtime guard cannot be what triggers the regeneration.
+  make_fake_tool "$moved_bin"
+  touch -t 200001010000 "$moved_bin/faketool"
+
+  run_cached_init "$moved_bin"
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"generation=2"* ]]
+  assert_generator_calls 2
+  assert_cache_entry_count 1
+
+  local expected_key
+  expected_key=$(printf '%s' "$moved_bin/faketool" | tr -c 'A-Za-z0-9._-' '_')
+  [[ $(cache_entries) == *"$expected_key"* ]]
+}
+
+@test "the cache key includes the running fish version" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  # A fish upgrade cannot be simulated in-process because $version is
+  # read-only, so assert the version reaches the key. The relocation test above
+  # already establishes that a changed key forces a regeneration.
+  [[ $(basename "$(cache_entries)") == *"-$fish_version.fish" ]]
+}
+
+@test "a newer binary invalidates the cache" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  # Age the cache instead of touching the binary, so the comparison is decided
+  # by mtime order rather than by filesystem timestamp granularity.
+  touch -t 200001010000 "$(cache_entries)"
+
+  run_cached_init
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"generation=2"* ]]
+  assert_generator_calls 2
+  assert_cache_entry_count 1
+}
+
+@test "a failing generator reports failure and preserves the previous cache" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  local cache_path checksum_before
+  cache_path=$(cache_entries)
+  checksum_before=$(cksum < "$cache_path")
+
+  make_failing_tool "$tool_bin"
+  touch -t 200001010000 "$cache_path"
+
+  run_cached_init
+
+  [ "$status" -ne 0 ]
+  [ "$(cksum < "$cache_path")" = "$checksum_before" ]
+  assert_cache_entry_count 1
+
+  # A half-written cache must never be left behind.
+  run bash -c 'ls "$1"/fish/*.new 2>/dev/null | wc -l | tr -d " "' _ "$cache_home"
+  [ "$output" = "0" ]
+}
+
+@test "regeneration removes stale variants including the legacy unkeyed cache" {
+  run_cached_init
+  [ "$status" -eq 0 ]
+
+  local cache_path
+  cache_path=$(cache_entries)
+  touch "$cache_home/fish/faketool-init.fish"
+  assert_cache_entry_count 2
+
+  touch -t 200001010000 "$cache_path"
+  run_cached_init
+
+  [ "$status" -eq 0 ]
+  assert_cache_entry_count 1
+  [ ! -e "$cache_home/fish/faketool-init.fish" ]
+}
+
+@test "a missing tool is a silent no-op" {
+  run_cached_init "$tool_bin" definitely-not-installed
+
+  [ "$status" -eq 0 ]
+  assert_generator_calls 0
+  assert_cache_entry_count 0
+}

--- a/tests/fish/test-helper.bash
+++ b/tests/fish/test-helper.bash
@@ -1,0 +1,109 @@
+# Bats fixtures intentionally expose these values as globals to the test file.
+# shellcheck disable=SC2034
+
+setup_fish_test() {
+  if ! command -v fish > /dev/null; then
+    skip "fish is not installed"
+  fi
+
+  project_root=$(cd "$BATS_TEST_DIRNAME/../.." && pwd)
+  function_under_test=$project_root/config/private_dot_config/private_fish/functions/_source_cached_init.fish
+  # $version is a fish variable and must reach fish unexpanded.
+  # shellcheck disable=SC2016
+  fish_version=$(fish --no-config --command 'echo $version')
+
+  test_root=$(mktemp -d "${TMPDIR:-/tmp}/fish-test.XXXXXX")
+  cache_home=$test_root/cache
+  tool_bin=$test_root/bin
+  moved_bin=$test_root/moved-bin
+  call_log=$test_root/generator-calls.log
+  base_path=$PATH
+
+  mkdir -p "$cache_home" "$tool_bin" "$moved_bin"
+  : > "$call_log"
+  make_fake_tool "$tool_bin"
+}
+
+teardown_fish_test() {
+  rm -rf "$test_root"
+}
+
+# A stand-in init generator. Every invocation appends to the call log, so a
+# cache hit leaves the log untouched while a regeneration grows it. The emitted
+# fish code carries the generation number, which lets a test tell whether the
+# script it sourced was freshly generated or served from cache.
+make_fake_tool() {
+  cat > "$1/faketool" << 'EOF'
+#!/bin/sh
+printf 'faketool\n' >> "$FAKE_TOOL_LOG"
+printf 'set -g FAKE_INIT_GENERATION %s\n' "$(wc -l < "$FAKE_TOOL_LOG" | tr -d ' ')"
+EOF
+  chmod +x "$1/faketool"
+}
+
+# Replaces the fake tool with one that fails without emitting anything.
+make_failing_tool() {
+  cat > "$1/faketool" << 'EOF'
+#!/bin/sh
+printf 'faketool\n' >> "$FAKE_TOOL_LOG"
+exit 1
+EOF
+  chmod +x "$1/faketool"
+}
+
+# Runs the function under test in a bare fish with an isolated cache, config
+# and PATH, so neither the caller's environment nor an already deployed copy of
+# the function can influence the result.
+run_cached_init() {
+  bin_dir=${1:-$tool_bin}
+  tool_name=${2:-faketool}
+
+  run env \
+    HOME="$test_root" \
+    XDG_CACHE_HOME="$cache_home" \
+    XDG_CONFIG_HOME="$test_root/config" \
+    XDG_DATA_HOME="$test_root/data" \
+    FAKE_TOOL_LOG="$call_log" \
+    PATH="$bin_dir:$base_path" \
+    fish --no-config --command "
+      source '$function_under_test'
+      _source_cached_init $tool_name $tool_name init
+      or exit 1
+      echo \"generation=\$FAKE_INIT_GENERATION\"
+    "
+}
+
+generator_calls() {
+  wc -l < "$call_log" | tr -d ' '
+}
+
+cache_entries() {
+  set -- "$cache_home"/fish/faketool-init*.fish
+  [ -e "$1" ] || return 0
+  printf '%s\n' "$@"
+}
+
+count_cache_entries() {
+  cache_entries | wc -l | tr -d ' '
+}
+
+assert_generator_calls() {
+  local expected=$1
+  local actual
+  actual=$(generator_calls)
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected %s generator call(s), got %s\n' "$expected" "$actual" >&3
+    return 1
+  fi
+}
+
+assert_cache_entry_count() {
+  local expected=$1
+  local actual
+  actual=$(count_cache_entries)
+  if [ "$actual" != "$expected" ]; then
+    printf 'expected %s cache entry/entries, got %s:\n' "$expected" "$actual" >&3
+    cache_entries | sed 's/^/  /' >&3
+    return 1
+  fi
+}


### PR DESCRIPTION
Follow-ups from #117.

## 1. CI swallowed fish template render failures

The `*.fish.tmpl` loop piped `chezmoi execute-template` straight into
`fish --no-execute`, so only fish's exit status was observed. A render failure
produced empty output, and `fish --no-execute` accepts an empty script, so the
step passed.

Each template is now rendered into a variable first, and render and syntax
failures are reported separately. Same bug class as the per-file `.fish` loop
fixed in #117.

Truth table, reproduced in a scratch tree under `bash -e`:

| template state | before | after |
| --- | --- | --- |
| valid | 0 | 0 |
| render failure | **0 (swallowed)** | 1 |
| syntax error | 127 | 1 |

The three real templates still pass.

## 2. `mise activate` output must not be cached

`_source_cached_init` was caching `mise activate fish`. That output is not
reusable: it embeds an absolute `PATH` snapshot plus resolved tool install
paths (for example `installs/uv/0.12.9/...`), and the helper invalidates only
on the mise binary's mtime.

The deployed cache demonstrated the bug: 102 lines containing 6
`functions --erase` lines and 2 literal `set -gx PATH` snapshots, generated
from an already-active mise session. Its mtime (Sep 6) was newer than the mise
binary (Sep 2), so the guard could never fire and a stale `PATH` was replayed
on every shell startup indefinitely.

`mise activate` is now sourced live. `direnv` and `zoxide` emit no such state
and remain cached.

Verified in an isolated `XDG_CONFIG_HOME` against two trusted fixture
directories pinning different `shfmt` versions plus a directory-scoped `[env]`
variable. Behaviour is identical before and after: `3.13.1` in A, `3.14.0` in
B, correct value on return to A, and unset outside both.

## Why the startup cost itself is not reduced

The `~25 ms` `mise hook-env` call at startup is irreducible without breaking
correctness. Measured warm, 30 runs each:

| | ms |
| --- | --- |
| fork+exec floor (`/bin/echo`) | 3.3 |
| `mise --version` | 9.2 |
| `mise hook-env -s fish` | 24.1 |
| bare fish | 6.8 |
| full config | 42.1 |

Across 5 warm startup profiles `hook-env` was 22.2-23.1 ms of it, and every
other config line was under 0.4 ms.

Options ruled out:

- **Caching `hook-env`** is unsound. Its output is a stateful transition from
  live shell state, carrying serialized `__MISE_DIFF` and `__MISE_SESSION`
  bookkeeping that later fast-path checks trust.
- **Shims** drop `[env]` variables from the interactive shell, which the
  fixture above proves are load-bearing.
- **Deferring to `fish_prompt`** is measurement theatre: fish runs prompt event
  handlers synchronously before painting, so only `fish -i -c exit` improves.
- **`MISE_ENV_CACHE=true`** measured as a no-op for fresh shells: `hook-env`
  24.6 -> 24.4 ms, startup 43.6 -> 44.2 ms, no cache artifacts written.
- **Cutting the global tool surface** scales at ~0.3 ms/tool with no dominant
  backend. Removing all 23 global tools saves 6.8 ms; realistic cuts save
  0.5-2.7 ms, below the +/-3 ms run-to-run noise. Left unchanged deliberately.

Sourcing `mise activate` live costs +5.2 ms (46.3 -> 51.5 ms, measured A/B in
isolated config trees). That is a deliberate trade of ~11% startup for the
elimination of silent stale-`PATH` replay.

## Checks

`prek run --all-files` passes all 25 hooks.