### PR TITLE
feat(opencode): local voice dictation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -37,6 +37,18 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+[A-Za-z_][A-Za-z0-9_]*=(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Update opencode plugin pins",
+      "managerFilePatterns": [
+        "/^config\\/private_dot_config\\/private_opencode\\/opencode\\.json$/",
+        "/^config\\/private_dot_config\\/private_opencode\\/tui\\.json$/"
+      ],
+      "matchStrings": [
+        "\"(?<depName>@?[\\w.-]+(?:/[\\w.-]+)?)@(?<currentValue>\\d[^\"]*)\""
+      ],
+      "datasourceTemplate": "npm"
     }
   ],
   "mise": {
@@ -175,6 +187,16 @@
       "description": "Allow for the slower release cadence of stable tooling",
       "matchPackageNames": ["koalaman/shellcheck"],
       "abandonmentThreshold": "2 years"
+    },
+    {
+      "description": "Match the commit style used for opencode plugin bumps",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [
+        "config/private_dot_config/private_opencode/opencode.json",
+        "config/private_dot_config/private_opencode/tui.json"
+      ],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "opencode"
     }
   ]
 }

--- a/bootstrap/ansible/config.yaml
+++ b/bootstrap/ansible/config.yaml
@@ -73,6 +73,9 @@ brew:
       - dockutil
       - switchaudio-osx
       - ffmpeg
+      - sox
+      - whisper-cpp
+      - ollama
       - gawk
       - gnu-sed
       - wget

--- a/bootstrap/voice-setup.sh
+++ b/bootstrap/voice-setup.sh
@@ -1,0 +1,234 @@
+#!/bin/sh
+# Provision the local voice dictation stack for the opencode-voice plugin.
+#
+#   mise run voice:setup
+
+set -eu
+
+# Frozen by hand. Renovate can bump neither: the whisper checksum has to be
+# re-measured alongside the revision, and ollama tags are not a datasource it
+# knows. The instruct-2507 suffix is load bearing -- see the Modelfile.
+whisper_model_file=ggml-large-v3-turbo-q5_0.bin
+whisper_model_revision=5359861c739e955e79d9a303bcbc70fb988958b1
+whisper_model_sha256=394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2
+ollama_base_model=qwen3:4b-instruct-2507-q4_K_M
+ollama_voice_model=voice-normalize
+
+whisper_agent=com.shmileee.whisper-voice-server
+ollama_agent=com.shmileee.ollama
+whisper_port=8081
+ollama_port=11434
+
+model_dir="${HOME}/.local/share/whisper-cpp"
+model_path="${model_dir}/${whisper_model_file}"
+modelfile="${HOME}/.config/ollama/voice-normalize.Modelfile"
+whisper_plist="${HOME}/Library/LaunchAgents/${whisper_agent}.plist"
+ollama_plist="${HOME}/Library/LaunchAgents/${ollama_agent}.plist"
+whisper_log="${HOME}/Library/Logs/whisper-voice-server.log"
+ollama_log="${HOME}/Library/Logs/ollama.log"
+domain="gui/$(id -u)"
+
+poll_delay="${DOTFILES_VOICE_POLL_DELAY:-1}"
+ollama_attempts="${DOTFILES_VOICE_OLLAMA_ATTEMPTS:-60}"
+health_attempts="${DOTFILES_VOICE_HEALTH_ATTEMPTS:-120}"
+completion_timeout=120
+
+phase() {
+  printf '==> %s\n' "$1"
+}
+
+step() {
+  printf '    %s\n' "$1"
+}
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 1
+}
+
+wait_for() {
+  wait_predicate=$1
+  wait_attempts=$2
+  wait_attempt=0
+  while [ "$wait_attempt" -lt "$wait_attempts" ]; do
+    if "$wait_predicate"; then
+      return 0
+    fi
+    sleep "$poll_delay"
+    wait_attempt=$((wait_attempt + 1))
+  done
+  return 1
+}
+
+digest() {
+  shasum -a 256 "$1" | cut -d ' ' -f 1
+}
+
+check_prerequisites() {
+  [ "$(uname -s)" = "Darwin" ] || fail 'voice:setup supports macOS only'
+
+  # whisper-server is checked on the LaunchAgent's behalf; this script never
+  # runs it.
+  for binary in ollama whisper-server; do
+    command -v "$binary" > /dev/null 2>&1 \
+      || fail "missing ${binary}: run 'mise run reconcile' first"
+  done
+
+  for managed in "$modelfile" "$whisper_plist" "$ollama_plist"; do
+    [ -r "$managed" ] || fail "missing ${managed}: run 'chezmoi apply' first"
+  done
+}
+
+sync_whisper_model() {
+  phase 'whisper transcription model'
+  if [ -r "$model_path" ] && [ "$(digest "$model_path")" = "$whisper_model_sha256" ]; then
+    step 'present and verified'
+    return 0
+  fi
+
+  step "downloading ${whisper_model_file} (547 MB)"
+  mkdir -p "$model_dir"
+  # Pinned revision, not main: the upstream branch is mutable.
+  curl -fL --progress-bar \
+    -o "${model_path}.partial" \
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/${whisper_model_revision}/${whisper_model_file}"
+
+  actual="$(digest "${model_path}.partial")"
+  if [ "$actual" != "$whisper_model_sha256" ]; then
+    rm -f "${model_path}.partial"
+    fail "checksum mismatch: expected ${whisper_model_sha256}, got ${actual}"
+  fi
+  # A corrupt model degrades transcription rather than failing, so it must not
+  # appear under the real name until verified.
+  mv "${model_path}.partial" "$model_path"
+  step 'verified'
+}
+
+agent_loaded() {
+  launchctl print "${domain}/$1" > /dev/null 2>&1
+}
+
+# `grep -q` closes the pipe on its first match, which would fail this under
+# `set -o pipefail`. That is why this script does not set it.
+agent_running() {
+  launchctl print "${domain}/$1" 2> /dev/null \
+    | grep -qE '^[[:space:]]+state = running'
+}
+
+# "keep" leaves an already-serving process alone: restarting ollama drops its
+# loaded models, and `ollama create` registers the derived model with the live
+# server anyway.
+start_agent() {
+  agent_label=$1
+  agent_plist=$2
+  agent_mode=$3
+
+  if ! agent_loaded "$agent_label"; then
+    launchctl bootstrap "$domain" "$agent_plist"
+    step 'loaded'
+  elif [ "$agent_mode" = force ]; then
+    launchctl kickstart -k "${domain}/${agent_label}"
+    step 'restarted'
+  elif agent_running "$agent_label"; then
+    step 'already running'
+  else
+    launchctl kickstart "${domain}/${agent_label}"
+    step 'started'
+  fi
+}
+
+ollama_listening() {
+  nc -z 127.0.0.1 "$ollama_port" 2> /dev/null
+}
+
+start_ollama() {
+  phase 'ollama service'
+  start_agent "$ollama_agent" "$ollama_plist" keep
+  wait_for ollama_listening "$ollama_attempts" \
+    || fail "ollama did not start on port ${ollama_port}; see ${ollama_log}"
+
+  # An open port is not proof the managed agent owns it.
+  agent_running "$ollama_agent" \
+    || fail "ollama answered but its LaunchAgent is not running; see ${ollama_log}"
+  step "serving on 127.0.0.1:${ollama_port}"
+}
+
+build_normalization_model() {
+  phase 'normalization model'
+  installed="$(ollama list)"
+  case $installed in
+    *"$ollama_base_model"*)
+      step 'base model present'
+      ;;
+    *)
+      step "pulling ${ollama_base_model} (2.5 GB)"
+      ollama pull "$ollama_base_model"
+      ;;
+  esac
+
+  # Rebuilt every run: a manifest over existing layers is free, and it is what
+  # picks up an edited Modelfile. Progress is raw terminal escapes on stderr.
+  if ! create_log="$(ollama create "$ollama_voice_model" -f "$modelfile" 2>&1)"; then
+    printf '%s\n' "$create_log" >&2
+    fail 'ollama create failed'
+  fi
+  step "built ${ollama_voice_model}"
+}
+
+whisper_healthy() {
+  [ "$(curl -s --max-time 2 "http://127.0.0.1:${whisper_port}/health")" = '{"status":"ok"}' ]
+}
+
+start_whisper() {
+  phase 'transcription service'
+  start_agent "$whisper_agent" "$whisper_plist" force
+
+  if ! wait_for whisper_healthy "$health_attempts"; then
+    if lsof -nP -iTCP:"${whisper_port}" -sTCP:LISTEN > /dev/null 2>&1; then
+      fail "port ${whisper_port} is held by another process; stop it and rerun"
+    fi
+    fail "whisper-server did not start; see ${whisper_log}"
+  fi
+
+  # Nor is /health: another whisper-server on 8081 would answer it.
+  agent_running "$whisper_agent" \
+    || fail "whisper-server answered but its LaunchAgent is not running; see ${whisper_log}"
+  step "healthy on 127.0.0.1:${whisper_port}"
+}
+
+verify_normalization_model() {
+  phase 'normalization endpoint'
+  # `ollama create` writes a manifest; it does not prove the model loads.
+  payload="$(printf \
+    '{"model":"%s","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}' \
+    "$ollama_voice_model")"
+
+  if ! response="$(curl -fsS --max-time "$completion_timeout" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    "http://127.0.0.1:${ollama_port}/v1/chat/completions" 2>&1)"; then
+    printf '%s\n' "$response" >&2
+    fail "${ollama_voice_model} did not answer a chat completion"
+  fi
+
+  case $response in
+    # Before the success case: a reasoning response contains both.
+    *'<think>'*)
+      fail "${ollama_voice_model} emitted a reasoning block; use a non-thinking base model"
+      ;;
+    *'"choices"'*)
+      step 'answering chat completions'
+      ;;
+    *)
+      fail "unexpected completion response: ${response}"
+      ;;
+  esac
+}
+
+check_prerequisites
+sync_whisper_model
+start_ollama
+build_normalization_model
+start_whisper
+verify_normalization_model
+printf '\nvoice stack ready\n'

--- a/config/.chezmoiignore
+++ b/config/.chezmoiignore
@@ -7,4 +7,8 @@ bin/open-url
 {{ if ne .chezmoi.os "darwin" }}
 .1password
 .1password/**
+Library
+Library/**
+bin/whisper-voice-server
+bin/ollama-serve
 {{ end }}

--- a/config/Library/LaunchAgents/com.shmileee.ollama.plist.tmpl
+++ b/config/Library/LaunchAgents/com.shmileee.ollama.plist.tmpl
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.shmileee.ollama</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ .chezmoi.homeDir }}/bin/ollama-serve</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- launchd hands over a minimal PATH; ollama lives in Homebrew. -->
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+
+        <!-- Only the local voice plugin talks to this server. -->
+        <key>OLLAMA_HOST</key>
+        <string>127.0.0.1:11434</string>
+
+        <!-- Inherited from the Homebrew plist this replaces, so the migration
+             does not change inference behaviour. -->
+        <key>OLLAMA_FLASH_ATTENTION</key>
+        <string>1</string>
+        <key>OLLAMA_KV_CACHE_TYPE</key>
+        <string>q8_0</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart on crash, but do not spin on a conflict only a human can clear. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ProcessType</key>
+    <string>Adaptive</string>
+
+    <key>StandardOutPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/ollama.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/ollama.log</string>
+</dict>
+</plist>

--- a/config/Library/LaunchAgents/com.shmileee.whisper-voice-server.plist.tmpl
+++ b/config/Library/LaunchAgents/com.shmileee.whisper-voice-server.plist.tmpl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.shmileee.whisper-voice-server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ .chezmoi.homeDir }}/bin/whisper-voice-server</string>
+    </array>
+
+    <!-- launchd hands over a minimal PATH; whisper-server lives in Homebrew. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Restart on crash, but do not spin on a conflict only a human can clear. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ProcessType</key>
+    <string>Adaptive</string>
+
+    <key>StandardOutPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/whisper-voice-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/whisper-voice-server.log</string>
+</dict>
+</plist>

--- a/config/bin/executable_ollama-serve
+++ b/config/bin/executable_ollama-serve
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Local ollama server backing the opencode-voice normalization step, started by
+# ~/Library/LaunchAgents/com.shmileee.ollama.plist, which declares the bind
+# address and tuning flags that `brew services start ollama` would otherwise
+# take from the formula.
+
+set -euo pipefail
+
+log="${HOME}/Library/Logs/ollama.log"
+log_limit=8388608
+
+# launchd never rotates this log and ollama logs every request. Truncating in
+# place is safe rather than sparse: the descriptor launchd handed us is
+# O_APPEND, so the next write lands at offset 0.
+if [ -f "$log" ] && [ "$(wc -c < "$log")" -gt "$log_limit" ]; then
+  : > "$log"
+  printf '[ollama-serve] truncated %s past %s bytes\n' "$log" "$log_limit"
+fi
+
+exec ollama serve

--- a/config/bin/executable_whisper-voice-server
+++ b/config/bin/executable_whisper-voice-server
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Local speech-to-text server for the opencode-voice plugin, started by
+# ~/Library/LaunchAgents/com.shmileee.whisper-voice-server.plist.
+#
+# The plugin's built-in whisper-cli invocation cannot pass a vocabulary;
+# whisper-server can, and the plugin can be pointed at it with sttEndpoint.
+#
+# Exit status is a restart signal, not a health report: the LaunchAgent sets
+# KeepAlive{SuccessfulExit=false}, so anything diagnosable here exits 0 to stay
+# stopped. Only whisper-server's own failures earn a restart.
+
+set -euo pipefail
+
+vocabulary="${HOME}/.config/opencode/voice-vocabulary.txt"
+model="${HOME}/.local/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin"
+log="${HOME}/Library/Logs/whisper-voice-server.log"
+host=127.0.0.1
+port=8081
+log_limit=1048576
+
+note() {
+  printf '[whisper-voice-server] %s\n' "$1"
+}
+
+stop() {
+  local line
+  for line in "$@"; do
+    note "$line" >&2
+  done
+  note 'staying stopped; rerun mise run voice:setup once this is resolved' >&2
+  exit 0
+}
+
+# launchd never rotates this log. Truncating in place is safe rather than
+# sparse: the descriptor launchd handed us is O_APPEND, so the next write lands
+# at offset 0.
+if [ -f "$log" ] && [ "$(wc -c < "$log")" -gt "$log_limit" ]; then
+  : > "$log"
+  note "truncated ${log} past ${log_limit} bytes"
+fi
+
+[ -r "$model" ] || stop \
+  "whisper model not readable: ${model}" \
+  'the model is downloaded by voice:setup, not by chezmoi'
+
+# whisper-server initialises Metal before it binds and its bind-failure path
+# reaches exit() with the ggml device still allocated, tripping
+# GGML_ASSERT([rsets->data count] == 0). A busy port therefore becomes a
+# SIGABRT, which KeepAlive retries every ThrottleInterval forever.
+#
+# Two probes, because each alone has a blind spot: lsof cannot see a listener
+# owned by another user, and `nc -z` reports a full listen backlog as a free
+# port -- which would let a conflicting server pass and still lose the bind.
+listing="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2> /dev/null || true)"
+if [ -n "$listing" ] || nc -z "$host" "$port" > /dev/null 2>&1; then
+  stop \
+    "${host}:${port} is already in use" \
+    "${listing:-identify the owner with: lsof -nP -iTCP:${port} -sTCP:LISTEN}"
+fi
+
+# whisper wants one line of context.
+prompt=""
+if [ -r "$vocabulary" ]; then
+  # Whole comment lines only: stripping from any '#' would truncate a term
+  # like C#. sed always exits 0, which matters under pipefail.
+  prompt="$(sed '/^[[:space:]]*#/d' "$vocabulary" | tr '\n' ' ' | tr -s '[:space:]' ' ')"
+fi
+
+# --inference-path matches what the plugin builds from sttEndpoint.
+# --carry-initial-prompt re-applies the vocabulary to every 30s window, so bias
+# does not decay on long dictations.
+exec whisper-server \
+  --model "$model" \
+  --host "$host" \
+  --port "$port" \
+  --inference-path /v1/audio/transcriptions \
+  --prompt "$prompt" \
+  --carry-initial-prompt

--- a/config/private_dot_config/ollama/voice-normalize.Modelfile
+++ b/config/private_dot_config/ollama/voice-normalize.Modelfile
@@ -1,0 +1,17 @@
+# Normalization model for the opencode-voice plugin. Built by voice:setup.
+#
+# The plugin sends only `model`, `max_tokens` and `messages`, so sampling cannot
+# be set from tui.json. Baking it into a derived model is ollama's documented
+# workaround.
+#
+# The plugin inserts choices[0].message.content verbatim, so the base must be a
+# non-thinking checkpoint or its <think> block lands in the prompt box.
+
+FROM qwen3:4b-instruct-2507-q4_K_M
+
+# Greedy decoding: even 0.1 normalizes the same transcript differently between
+# runs.
+PARAMETER temperature 0
+
+# Dictated prompts are short; the 256K default reserves memory for nothing.
+PARAMETER num_ctx 4096

--- a/config/private_dot_config/private_opencode/tui.json
+++ b/config/private_dot_config/private_opencode/tui.json
@@ -1,7 +1,19 @@
 {
   "$schema": "https://opencode.ai/tui.json",
   "theme": "tokyonight-transparent",
+  "keybinds": {
+    "session_rename": "none"
+  },
   "plugin": [
-    "oh-my-openagent@5.0.0-beta.46"
+    "oh-my-openagent@5.0.0-beta.46",
+    [
+      "@renjfk/opencode-voice@0.6.0",
+      {
+        "endpoint": "http://localhost:11434/v1",
+        "model": "voice-normalize",
+        "sttPrompt": "~/.config/opencode/voice-stt-prompt.md",
+        "sttEndpoint": "http://127.0.0.1:8081/v1"
+      }
+    ]
   ]
 }

--- a/config/private_dot_config/private_opencode/voice-stt-prompt.md
+++ b/config/private_dot_config/private_opencode/voice-stt-prompt.md
@@ -1,0 +1,121 @@
+You are a speech-to-text normalizer for a coding assistant CLI.
+
+Clean up raw whisper transcription into a clear, well-punctuated prompt. Rules:
+
+*   Fix punctuation, capitalization, and grammar
+*   Remove filler words (um, uh, like, you know, so yeah, etc.)
+*   Keep technical terms, file names, and code references exact
+*   If the user is dictating code, format it appropriately
+*   Use the session context above to resolve ambiguous references (e.g. "that
+    function", "the file", "it")
+*   Output ONLY the cleaned text, nothing else
+*   Do not add any commentary or explanation
+*   Keep the user's intent and meaning intact
+
+## Preserve the utterance
+
+Whisper mangles unfamiliar tool names, and guessing at them destroys the
+prompt. These rules override every correction below:
+
+*   NEVER replace an unrecognised word with a real word that merely sounds
+    similar. An odd-looking token is far more likely to be a tool name than a
+    mistake.
+*   If a token is not in the vocabulary below and you cannot identify it, leave
+    it EXACTLY as transcribed. A wrong-looking name the user can spot beats a
+    plausible name they will miss.
+*   NEVER introduce words that were not spoken. Do not infer subcommands, flags,
+    or verbs the user did not say.
+*   NEVER reorder or merge clauses. Keep the original sentence structure and
+    order of operations.
+*   NEVER answer, summarise, or respond to the text. It is a prompt being
+    dictated, not a question addressed to you. Even a one-word transcript like
+    "hey" is passed through, not greeted.
+
+## Project vocabulary
+
+These are real tools in this user's environment. Restore them when the
+transcription is close:
+
+Dotfiles and shell: chezmoi, prek, mise, ghq, direnv, fish, starship, homebrew,
+launchd, ansible, bats
+
+CLI tools: eza, jaq, yq, fd, fzf, bat, duf, dust, sponge, zoxide, ripgrep,
+git-delta, git-lfs, gh, lazygit, tmux, workmux, alacritty, neovim, LazyVim, k9s
+
+Infra: kubectl, helm, terraform, terramate, vault, aws-vault, docker,
+1password, session-manager-plugin
+
+Linters and formatters: gitleaks, zizmor, actionlint, yamllint, ansible-lint,
+shellcheck, shfmt, biome, ruff, stylua, taplo, rumdl, oxfmt, oxlint,
+golangci-lint, renovate
+
+Voice and media: whisper-cpp, whisper-cli, piper, sox, ffmpeg, ollama
+
+Runtimes: uv, bun, node, python, go, ruby, pipx, aqua, npm
+
+Editor and agents: opencode, chezmoi apply, chezmoi diff, tokyonight
+
+## Observed mistranscriptions
+
+whisper-server already biases transcription toward the vocabulary above, so
+most tool names arrive correct. This list only repairs the residue.
+
+It is short on purpose. Earlier revisions mapped forms that turned out to be
+ordinary words, personal names or plausible phrases, and each one silently
+rewrote real sentences. A source form qualifies only if it is meaningless in
+English AND was actually observed coming out of the biased pipeline.
+
+Apply ONLY the rules written below this line. Do not infer additional
+corrections by analogy, and do not extend a rule to a similar-sounding word.
+
+*   "chesmoy" / "chesmoi" / "chemsy" -> "chezmoi"
+*   "chezmoi implies" -> "chezmoi apply" (only directly after chezmoi)
+*   "preck" / "prec" -> "prek"
+*   "execprec" / "execprek" / "exec prec" -> "exec prek"
+*   "diorinv" / "dyeronv" / "dieronv" -> "direnv"
+*   "zizmer" / "zimer" -> "zizmor"
+*   "zoxite" / "zopsight" -> "zoxide"
+*   "alicrity" -> "alacritty"
+*   "iza" / "eiza" -> "eza"
+*   "tomel" -> "TOML"
+*   "terra mate" -> "terramate"
+*   "g h q" -> "ghq"
+*   "s h f m t" -> "shfmt"
+*   "k nines" -> "k9s"
+*   "whisper c p p" / "whisper c plus plus" -> "whisper-cpp"
+*   a stray leading "@" before a tool name is a whisper artifact: drop it
+    ("@zoxide" -> "zoxide")
+*   NEVER convert between "jq" and "jaq". Both are installed and both are used
+    in this repo, so whichever was transcribed stands.
+*   "o llama" / "oh llama" -> "ollama"
+*   "open code" -> "opencode"
+
+## Domain corrections
+
+Transcription is already vocabulary-biased upstream by whisper-server, so tool
+names mostly arrive correct and this section stays deliberately tiny.
+
+Map ONLY this one. "yamel" was removed after it rewrote the given name Yamel,
+and "tomel" is already covered above:
+
+*   "pee r" -> "PR"
+
+Terms like docker, boolean, TypeScript, JSON, append, async and cache are not
+corrected at all, on purpose. Mapping them here damages ordinary speech, and
+adding them to voice-vocabulary.txt measurably degraded whisper's bias on the
+rarer tool names that actually need it. Whisper usually gets them right
+unaided, so both layers leave them alone.
+
+Everything else stands exactly as transcribed. These are ordinary English and
+must pass through untouched, whatever they sound like:
+
+```
+cash    locks   bite    byte    get     no      note
+sink    doc     rap     react   Jason   repo    bullion
+talker  types   script  app
+```
+
+A visibly wrong tool name is recoverable; a silently rewritten sentence is not.
+
+Capitalization still applies: the pronoun "I" is always capital, and sentences
+start with a capital letter.

--- a/config/private_dot_config/private_opencode/voice-vocabulary.txt
+++ b/config/private_dot_config/private_opencode/voice-vocabulary.txt
@@ -1,0 +1,18 @@
+# Vocabulary fed to whisper as an initial prompt, biasing transcription toward
+# the tools actually used on this machine. Lines starting with # are stripped;
+# everything else is flattened to one line and passed as --prompt.
+#
+# Keep this SHORT. whisper caps the initial prompt at n_text_ctx/2 (~224
+# tokens) and silently keeps only the LAST 224, so overflowing it drops the
+# entries at the top of this list. Add terms that get mangled, not every
+# binary installed -- padding with words whisper already knows measurably
+# degrades bias on the rare ones that need it.
+#
+# Read only at service start: run `mise run voice:setup` after editing.
+
+Tools: chezmoi, prek, mise, ghq, direnv, eza, jaq, yq, zoxide, alacritty,
+zizmor, terramate, actionlint, yamllint, ansible-lint, shellcheck, shfmt,
+gitleaks, rumdl, taplo, stylua, biome, ruff, renovate, lazygit, workmux, tmux,
+neovim, LazyVim, ripgrep, fzf, k9s, kubectl, helm, terraform, vault, aws-vault,
+ollama, whisper-cpp, piper, sox, ffmpeg, opencode, homebrew, launchd, bats,
+uv, bun, golangci-lint, pipx, aqua, tokyonight, dotfiles, worktree.

--- a/docs/content/opencode.md
+++ b/docs/content/opencode.md
@@ -1,11 +1,12 @@
 ---
 title: OpenCode configuration
-description: Local secrets, model routing, corporate overlays, and contextual notifications.
+description: Local secrets, model routing, corporate overlays, contextual notifications, and local voice dictation.
 tags:
   - OpenCode
   - AI tooling
   - tmux
   - chezmoi
+  - Voice
 hide:
   - tags
 ---
@@ -29,6 +30,7 @@ hide:
   <div><dt>Model routing</dt><dd>Rules that choose a primary model and fallbacks for each kind of task.</dd></div>
   <div><dt>Hook</dt><dd>Logic that runs automatically when a specific OpenCode event occurs.</dd></div>
   <div><dt>TPM</dt><dd>The tmux Plugin Manager, used to install and update tmux extensions.</dd></div>
+  <div><dt>LaunchAgent</dt><dd>A macOS service definition that launchd starts and keeps running for the logged-in user.</dd></div>
 </dl>
 </div>
 </dialog>
@@ -57,11 +59,17 @@ hide:
     <a class="repo-path" href="https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf" aria-label="Open the managed tmux configuration on GitHub"><code class="path-token">~/.config/<wbr>tmux/<wbr>tmux.conf</code></a>
     <p>Installs the contextual-notifier companion plugin.</p>
   </article>
+  <article>
+    <span>OpenCode TUI</span>
+    <a class="repo-path" href="https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_opencode/tui.json" aria-label="Open the managed OpenCode TUI configuration on GitHub"><code class="path-token">~/.config/<wbr>opencode/<wbr>tui.json</code></a>
+    <p>Theme, keybinds, and the client-side plugins including voice dictation.</p>
+  </article>
 </div>
 
-The OpenCode configuration currently declares the `opencode-claude-auth`, Oh
-My OpenAgent, and contextual-notifier plugins. OpenCode installs these plugins
-with Bun when it starts.
+`opencode.json` declares the `opencode-claude-auth`, Oh My OpenAgent, and
+contextual-notifier plugins. The TUI loads its own `tui.json`, which declares
+Oh My OpenAgent again alongside the voice plugin. OpenCode installs every
+declared plugin with Bun when it starts.
 
 ## First-run checklist
 
@@ -154,13 +162,87 @@ After changing the notifier declaration:
 2.  Reload tmux with ++ctrl+a++ then ++ctrl+r++.
 3.  Run the TPM installation flow if the companion plugin is not present.
 
+## Voice dictation
+
+++ctrl+r++ records a prompt, transcribes it, and inserts the cleaned text into
+the prompt box. Both models run on this machine, so no audio leaves it.
+
+The plugin is declared in the managed
+[`tui.json`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_opencode/tui.json),
+which also frees ++ctrl+r++ by disabling the factory `session_rename`
+binding—rename a session with `/rename` instead. The plugin talks to two local
+services:
+
+<div class="surface-grid">
+  <article>
+    <span>Transcription</span>
+    <code class="path-token">127.0.0.1:8081</code>
+    <p>whisper.cpp behind a managed LaunchAgent, biased with a project vocabulary.</p>
+  </article>
+  <article>
+    <span>Normalization</span>
+    <code class="path-token">127.0.0.1:11434</code>
+    <p>ollama serving <code>voice-normalize</code>, which repunctuates the raw transcript.</p>
+  </article>
+</div>
+
+The models are roughly 3 GB, so they are installed on demand rather than during
+provisioning:
+
+```bash
+mise run voice:setup
+```
+
+The task is idempotent. It verifies the whisper checksum, brings ollama up,
+rebuilds the derived model from its Modelfile, restarts the transcription
+service, and probes both endpoints before reporting success.
+
+| Managed file | Role |
+| --- | --- |
+| `bin/whisper-voice-server` | Starts `whisper-server` with the vocabulary as its initial prompt. |
+| `bin/ollama-serve` | Starts `ollama serve` and caps its log. |
+| `.config/ollama/voice-normalize.Modelfile` | Pins the base checkpoint and bakes in deterministic sampling. |
+| `.config/opencode/voice-vocabulary.txt` | Tool names fed to whisper so it stops mangling them. |
+| `.config/opencode/voice-stt-prompt.md` | System prompt that cleans up the raw transcript. |
+
+Both services are LaunchAgents declared in this repository rather than
+`brew services` entries, so the bind address, tuning flags, and log paths are
+reviewable here instead of being whatever the Homebrew formula ships. Nothing
+in this repository starts `brew services`, so a machine that had the Homebrew
+`ollama` service running needs it stopped once by hand—it binds the same port.
+
+| Managed service | Role |
+| --- | --- |
+| `Library/LaunchAgents/com.shmileee.whisper-voice-server.plist` | Keeps whisper.cpp running and owns `~/Library/Logs/whisper-voice-server.log`. |
+| `Library/LaunchAgents/com.shmileee.ollama.plist` | Keeps `ollama serve` bound to loopback and owns `~/Library/Logs/ollama.log`. |
+
+Neither log is rotated by launchd, so each wrapper truncates its own in place
+once it grows past a limit.
+
+### Editing the vocabulary or the prompt
+
+The two text files reload differently:
+
+*   `voice-vocabulary.txt` is read by `whisper-server` when it starts, so it
+    needs a service restart: `chezmoi apply` then `mise run voice:setup`.
+*   `voice-stt-prompt.md` is read by the plugin when OpenCode starts, so it
+    needs `chezmoi apply` and an OpenCode restart. `voice:setup` does nothing
+    for it.
+
+!!! warning "whisper truncates a long vocabulary from the front"
+
+    The initial prompt is capped at 224 tokens and whisper keeps the last 223,
+    so a vocabulary that grows past the cap loses its opening entries in
+    silence. Add terms that are actually mangled rather than every installed
+    binary.
+
 ## Deliberately unmanaged
 
 <div class="boundary-list">
   <div><code>opencode.corp.json</code><span>Company-specific configuration</span></div>
   <div><code>opencode/secrets/</code><span>Credentials and private endpoints</span></div>
-  <div><code>tui.json</code><span>A separate server-side extension surface</span></div>
   <div><strong>Runtime files</strong><span>Caches, backups, lockfiles, and dependency directories</span></div>
+  <div><strong>Voice models</strong><span>The whisper weights and ollama blobs installed by <code>voice:setup</code></span></div>
 </div>
 
 ## Troubleshooting
@@ -191,3 +273,55 @@ functions opencode | grep -q workgit; and echo wrapper active
 
 Focus the originating tmux window first. If the marker remains, restart
 OpenCode and reload tmux configuration with ++ctrl+a++ then ++ctrl+r++.
+
+### Voice recording does nothing
+
+Check that the transcription service is loaded, running, and answering:
+
+```bash
+launchctl print "gui/$(id -u)/com.shmileee.whisper-voice-server" | grep 'state ='
+curl -s http://127.0.0.1:8081/health
+```
+
+A job that is loaded but not running means the wrapper diagnosed something and
+stopped deliberately—it reports success so launchd does not retry a condition
+only a person can clear. The reason is at the end of its log:
+
+```bash
+tail -n 20 ~/Library/Logs/whisper-voice-server.log
+```
+
+It reports two: a missing model, cleared by `mise run voice:setup`, and another
+process already holding the port.
+
+```bash
+lsof -nP -iTCP:8081 -sTCP:LISTEN
+```
+
+### Dictation is transcribed but the inserted text is wrong
+
+That is the normalization step rather than whisper. Confirm its agent is up and
+the derived model answers:
+
+```bash
+launchctl print "gui/$(id -u)/com.shmileee.ollama" | grep 'state ='
+ollama list | grep voice-normalize
+curl -s http://127.0.0.1:11434/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"voice-normalize","max_tokens":16,"messages":[{"role":"user","content":"ping"}]}'
+```
+
+`mise run voice:setup` runs the same probe and rebuilds the model from its
+Modelfile.
+
+If the agent will not stay up, check that a Homebrew service is not competing
+for the port. Only a machine provisioned before this agent existed can have
+one, and stopping it is a one-time fix:
+
+```bash
+brew services list | grep ollama
+```
+
+```bash
+brew services stop ollama
+```

--- a/docs/content/setup.md
+++ b/docs/content/setup.md
@@ -197,6 +197,7 @@ insecure setting is written.
 | `./bootstrap/setup.sh` | Bootstrap a workstation or recover a valid incomplete persistent clone. |
 | `mise run reconcile` | Run normal ongoing reconciliation from a completed checkout. |
 | `mise run reconcile:check` | Preview supported changes after bootstrap. |
+| `mise run voice:setup` | Download the voice dictation models and start the local transcription service. Manual because it fetches ~3 GB. |
 
 </div>
 

--- a/docs/content/shortcuts.md
+++ b/docs/content/shortcuts.md
@@ -1,6 +1,6 @@
 ---
 title: Shortcut reference
-description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, and Neovim.
+description: Keyboard shortcuts configured for macOS, Alacritty, fish, tmux, Neovim, and OpenCode.
 tags:
   - Shortcuts
   - macOS
@@ -8,6 +8,7 @@ tags:
   - fish
   - tmux
   - Neovim
+  - OpenCode
 hide:
   - tags
 ---
@@ -29,6 +30,7 @@ hide:
     <button type="button" aria-pressed="false" data-shortcut-scope="fish">fish</button>
     <button type="button" aria-pressed="false" data-shortcut-scope="tmux">tmux</button>
     <button type="button" aria-pressed="false" data-shortcut-scope="neovim">Neovim</button>
+    <button type="button" aria-pressed="false" data-shortcut-scope="opencode">OpenCode</button>
   </div>
   <p class="shortcut-filter__status" aria-live="polite" data-shortcut-status></p>
 </div>
@@ -198,6 +200,22 @@ LazyVim provides most editor mappings. This repository adds only a small set:
 
 </section>
 
+<section class="shortcut-reference shortcut-filter-section" data-shortcut-section="opencode" markdown>
+
+## OpenCode
+
+These act inside the OpenCode TUI, so the tmux prefix is not involved.
+
+| Shortcut | Action |
+| --- | --- |
+| ++ctrl+r++ | Record a voice prompt, transcribe it, and insert the cleaned text |
+
+++ctrl+r++ is OpenCode's factory binding for renaming a session. The managed
+`tui.json` disables that binding so the voice plugin can own the key; rename a
+session with the `/rename` command instead.
+
+</section>
+
 ## Source of truth
 
 *   macOS shortcuts:
@@ -210,3 +228,5 @@ LazyVim provides most editor mappings. This repository adds only a small set:
     [`tmux.conf`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_tmux/tmux.conf)
 *   Neovim additions:
     [`keymaps.lua`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/nvim/lua/config/keymaps.lua)
+*   OpenCode keybinds and voice plugin:
+    [`tui.json`](https://github.com/shmileee/dotfiles/blob/master/config/private_dot_config/private_opencode/tui.json)

--- a/mise/conf.d/20-bootstrap.toml
+++ b/mise/conf.d/20-bootstrap.toml
@@ -20,6 +20,13 @@ description = "Validate and report the locked runtime and pinned collections"
 depends = ["ansible:prepare"]
 run = "env ANSIBLE_COLLECTIONS_PATH=bootstrap/.ansible/collections uv run --project bootstrap --locked --managed-python python bootstrap/validate_runtime.py --collections-path bootstrap/.ansible/collections"
 
+# Kept out of the Ansible run on purpose: ~3 GB of model blobs that an
+# ephemeral CI runner would download and discard on every provisioning check.
+[tasks."voice:setup"]
+description = "Download the voice models and start the local transcription service"
+run = "bootstrap/voice-setup.sh"
+raw = true
+
 [tasks."test:bats"]
 description = "Run black-box bootstrap behavior tests"
 run = "bats tests/bootstrap"

--- a/tests/bootstrap/voice-setup.bats
+++ b/tests/bootstrap/voice-setup.bats
@@ -1,0 +1,328 @@
+#!/usr/bin/env bats
+
+# Bats exposes setup fixtures as globals and passes TEST_* controls to helpers.
+# shellcheck disable=SC2034,SC2154
+
+load voice-test-helper.bash
+
+setup() {
+  setup_voice_test
+}
+
+teardown() {
+  teardown_voice_test
+}
+
+@test "the voice provisioner parses under Dash and /bin/sh" {
+  run "$dash_path" -n "$voice_setup"
+  [ "$status" -eq 0 ]
+
+  run /bin/sh -n "$voice_setup"
+  [ "$status" -eq 0 ]
+}
+
+@test "the pinned model identity is internally consistent" {
+  [ "$expected_model_file" = ggml-large-v3-turbo-q5_0.bin ]
+  [ "${#expected_model_sha256}" -eq 64 ]
+  [ "${#expected_model_revision}" -eq 40 ]
+  # A thinking checkpoint would paste its reasoning into the prompt box.
+  [[ $expected_base_model == *-instruct-* ]]
+}
+
+@test "non-macOS hosts are refused before any mutation" {
+  TEST_OS=Linux
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"supports macOS only"* ]]
+  refute_log_contains "ollama"
+  refute_log_contains "curl"
+  refute_log_contains "launchctl"
+}
+
+@test "a missing dependency names itself and points at reconcile" {
+  rm "$fake_bin/ollama"
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"missing ollama"* ]]
+  [[ $output == *"mise run reconcile"* ]]
+  refute_log_contains "launchctl"
+  refute_log_contains "curl"
+}
+
+@test "every unapplied chezmoi input is reported instead of provisioned around" {
+  for managed in "$modelfile" "$whisper_plist" "$ollama_plist"; do
+    moved=$managed.moved
+    mv "$managed" "$moved"
+
+    run_voice_setup
+
+    [ "$status" -eq 1 ]
+    [[ $output == *"${managed##*/}"* ]]
+    [[ $output == *"chezmoi apply"* ]]
+    refute_log_contains "curl"
+
+    mv "$moved" "$managed"
+  done
+}
+
+@test "a verified model on disk is not downloaded again" {
+  install_verified_model
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"present and verified"* ]]
+  refute_log_contains "huggingface.co"
+}
+
+@test "a missing model is fetched from the pinned revision and published atomically" {
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "huggingface.co/ggerganov/whisper.cpp/resolve/$expected_model_revision/$expected_model_file"
+  [ -f "$model_path" ]
+  [ ! -e "$model_path.partial" ]
+  [[ $output == *"verified"* ]]
+}
+
+@test "a corrupt download is discarded rather than published" {
+  TEST_MODEL_DIGEST=0000000000000000000000000000000000000000000000000000000000000000
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"checksum mismatch"* ]]
+  [[ $output == *"$expected_model_sha256"* ]]
+  [ ! -e "$model_path" ]
+  [ ! -e "$model_path.partial" ]
+  refute_log_contains "ollama create"
+}
+
+@test "a failed model download stops before either service is touched" {
+  TEST_MODEL_CURL_STATUS=22
+
+  run_voice_setup
+
+  [ "$status" -ne 0 ]
+  refute_log_contains "launchctl bootstrap"
+  refute_log_contains "launchctl kickstart"
+  refute_log_contains "ollama create"
+}
+
+@test "an unloaded ollama agent is bootstrapped from the managed plist" {
+  install_verified_model
+  set_agent_state "$ollama_agent" false 'not running' 0
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "launchctl bootstrap gui/501 $ollama_plist"
+  [ "$(agent_field "$ollama_agent" loaded)" = true ]
+}
+
+@test "a loaded but stopped ollama agent is started without killing anything" {
+  install_verified_model
+  set_agent_state "$ollama_agent" true waiting 2234
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "launchctl kickstart gui/501/$ollama_agent"
+  refute_log_contains "kickstart -k gui/501/$ollama_agent"
+  [[ $output == *"started"* ]]
+}
+
+@test "an already running ollama agent is not restarted" {
+  install_verified_model
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"already running"* ]]
+  # Restarting would drop the loaded model: `ollama create` registers the
+  # derived model with the server that is already up.
+  refute_log_contains "kickstart gui/501/$ollama_agent"
+  refute_log_contains "kickstart -k gui/501/$ollama_agent"
+  [ "$(agent_field "$ollama_agent" pid)" -eq 2234 ]
+}
+
+@test "ollama that never listens fails with the port and its log" {
+  install_verified_model
+  TEST_NC_STATUS=1
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"ollama did not start on port 11434"* ]]
+  [[ $output == *"Logs/ollama.log"* ]]
+  refute_log_contains "ollama create"
+}
+
+@test "an ollama endpoint answering beside a stopped agent is still a failure" {
+  install_verified_model
+  set_agent_state "$ollama_agent" true waiting 2234
+  TEST_KICKSTART_STATE=waiting
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"ollama answered but its LaunchAgent is not running"* ]]
+}
+
+@test "an absent base model is pulled before the derived model is built" {
+  install_verified_model
+  TEST_OLLAMA_LIST=
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "ollama pull $expected_base_model"
+  assert_log_contains "ollama create $expected_voice_model"
+}
+
+@test "a present base model is not pulled again but is always rebuilt" {
+  install_verified_model
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  [[ $output == *"base model present"* ]]
+  refute_log_contains "ollama pull"
+  assert_log_contains "ollama create $expected_voice_model"
+}
+
+@test "a failed ollama create surfaces the tool's own output" {
+  install_verified_model
+  TEST_OLLAMA_CREATE_STATUS=1
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"ollama create failed"* ]]
+  [[ $output == *"writing manifest"* ]]
+  refute_log_contains "kickstart -k"
+}
+
+@test "an unloaded transcription agent is bootstrapped rather than kickstarted" {
+  install_verified_model
+  set_agent_state "$whisper_agent" false 'not running' 0
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "launchctl bootstrap gui/501 $whisper_plist"
+  refute_log_contains "kickstart -k"
+  [[ $output == *"loaded"* ]]
+}
+
+@test "a loaded transcription agent is replaced rather than left alone" {
+  install_verified_model
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "launchctl kickstart -k gui/501/$whisper_agent"
+  [[ $output == *"restarted"* ]]
+  # `kickstart -k` kills the old process first, so the vocabulary is re-read.
+  refute_log_contains "kickstart gui/501/$whisper_agent"
+}
+
+
+@test "an unhealthy service with a foreign listener names the port conflict" {
+  install_verified_model
+  TEST_HEALTH_BODY=nothing-listening-here
+  TEST_LSOF_STATUS=0
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"port 8081 is held by another process"* ]]
+  assert_log_contains "lsof -nP -iTCP:8081 -sTCP:LISTEN"
+}
+
+@test "an unhealthy service on a free port points at the service log" {
+  install_verified_model
+  TEST_HEALTH_BODY=nothing-listening-here
+  TEST_LSOF_STATUS=1
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"whisper-server did not start"* ]]
+  [[ $output == *"whisper-voice-server.log"* ]]
+}
+
+@test "a healthy endpoint beside a stopped transcription agent is still a failure" {
+  install_verified_model
+  # A started replacement that launchd still reports as stopped: what the
+  # wrapper's deliberate exit 0 looks like from here.
+  TEST_KICKSTART_STATE=waiting
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"whisper-server answered but its LaunchAgent is not running"* ]]
+}
+
+@test "a normalization endpoint that refuses the request fails loudly" {
+  install_verified_model
+  TEST_COMPLETION_STATUS=7
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"did not answer a chat completion"* ]]
+  [[ $output == *"could not reach the endpoint"* ]]
+}
+
+@test "a reasoning block in the completion is rejected" {
+  install_verified_model
+  TEST_COMPLETION_BODY='{"choices":[{"message":{"content":"<think>hmm</think>ping"}}]}'
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"emitted a reasoning block"* ]]
+  [[ $output == *"non-thinking base model"* ]]
+}
+
+@test "a response without completion choices is rejected" {
+  install_verified_model
+  TEST_COMPLETION_BODY='{"error":{"message":"model not found"}}'
+
+  run_voice_setup
+
+  [ "$status" -eq 1 ]
+  [[ $output == *"unexpected completion response"* ]]
+  [[ $output == *"model not found"* ]]
+}
+
+@test "the completion probe uses the derived model on the plugin's endpoint" {
+  install_verified_model
+
+  run_voice_setup
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "curl http://127.0.0.1:11434/v1/chat/completions"
+}
+
+@test "phase messages are ordered and completion is reported under both shells" {
+  install_verified_model
+
+  for shell_under_test in "$dash_path" /bin/sh; do
+    : > "$command_log"
+    set_agent_state "$whisper_agent" true running 1234
+    run_voice_setup "$shell_under_test"
+
+    [ "$status" -eq 0 ]
+    [[ $output =~ transcription\ model.*ollama\ service.*normalization\ model.*transcription\ service.*normalization\ endpoint ]]
+    [[ $output == *"serving on 127.0.0.1:11434"* ]]
+    [[ $output == *"healthy on 127.0.0.1:8081"* ]]
+    [[ $output == *"answering chat completions"* ]]
+    [[ $output == *"voice stack ready"* ]]
+  done
+}

--- a/tests/bootstrap/voice-test-helper.bash
+++ b/tests/bootstrap/voice-test-helper.bash
@@ -1,0 +1,230 @@
+# Bats fixtures intentionally expose these values as globals to the test file.
+# shellcheck disable=SC2034
+
+setup_voice_test() {
+  project_root=$(cd "$BATS_TEST_DIRNAME/../.." && pwd)
+  voice_setup=$project_root/bootstrap/voice-setup.sh
+  test_root=$(mktemp -d "${TMPDIR:-/tmp}/voice-test.XXXXXX")
+  test_home=$test_root/home
+  fake_bin=$test_root/fake-bin
+  base_bin=$test_root/base-bin
+  command_log=$test_root/commands.log
+  agent_dir=$test_root/agents
+  dash_path=$(command -v dash)
+
+  # Read back out of the script so assertions cannot drift from the real values.
+  expected_model_file=$(sed -n 's/^whisper_model_file=//p' "$voice_setup")
+  expected_model_revision=$(sed -n 's/^whisper_model_revision=//p' "$voice_setup")
+  expected_model_sha256=$(sed -n 's/^whisper_model_sha256=//p' "$voice_setup")
+  expected_base_model=$(sed -n 's/^ollama_base_model=//p' "$voice_setup")
+  expected_voice_model=$(sed -n 's/^ollama_voice_model=//p' "$voice_setup")
+  whisper_agent=$(sed -n 's/^whisper_agent=//p' "$voice_setup")
+  ollama_agent=$(sed -n 's/^ollama_agent=//p' "$voice_setup")
+
+  model_dir=$test_home/.local/share/whisper-cpp
+  model_path=$model_dir/$expected_model_file
+  modelfile=$test_home/.config/ollama/voice-normalize.Modelfile
+  whisper_plist=$test_home/Library/LaunchAgents/$whisper_agent.plist
+  ollama_plist=$test_home/Library/LaunchAgents/$ollama_agent.plist
+
+  # Not inlined below: a literal '}' inside ${var-default} needs escaping, and
+  # getting that wrong silently changes the fixture.
+  default_health_body='{"status":"ok"}'
+  default_completion_body='{"choices":[{"message":{"content":"ping"}}]}'
+
+  mkdir -p "$test_home" "$fake_bin" "$base_bin" "$agent_dir" \
+    "$(dirname "$modelfile")" "$(dirname "$whisper_plist")"
+  : > "$command_log"
+
+  printf 'FROM %s\n' "$expected_base_model" > "$modelfile"
+  printf 'managed plist\n' > "$whisper_plist"
+  printf 'managed plist\n' > "$ollama_plist"
+
+  # Tests move these with set_agent_state.
+  set_agent_state "$whisper_agent" true running 1234
+  set_agent_state "$ollama_agent" true running 2234
+
+  for command_name in cat cut grep mkdir mv rm sed sleep; do
+    ln -s "$(command -v "$command_name")" "$base_bin/$command_name"
+  done
+
+  make_voice_mock uname << 'EOF'
+printf 'uname %s\n' "${1:-}" >>"$MOCK_LOG"
+case ${1:-} in
+  -s) printf '%s\n' "$TEST_OS" ;;
+  *) exit 64 ;;
+esac
+EOF
+
+  make_voice_mock id << 'EOF'
+case ${1:-} in
+  -u) printf '501\n' ;;
+  *) exit 64 ;;
+esac
+EOF
+
+  # Present only so `command -v` resolves it; the setup script never runs it.
+  make_voice_mock whisper-server << 'EOF'
+printf 'whisper-server %s\n' "$*" >>"$MOCK_LOG"
+EOF
+
+  make_voice_mock nc << 'EOF'
+printf 'nc %s\n' "$*" >>"$MOCK_LOG"
+exit "$TEST_NC_STATUS"
+EOF
+
+  make_voice_mock lsof << 'EOF'
+printf 'lsof %s\n' "$*" >>"$MOCK_LOG"
+exit "$TEST_LSOF_STATUS"
+EOF
+
+  make_voice_mock shasum << 'EOF'
+printf 'shasum %s\n' "$*" >>"$MOCK_LOG"
+printf '%s  %s\n' "$TEST_MODEL_DIGEST" "$3"
+EOF
+
+  make_voice_mock ollama << 'EOF'
+printf 'ollama %s\n' "$*" >>"$MOCK_LOG"
+case ${1:-} in
+  list)
+    printf 'NAME ID SIZE MODIFIED\n'
+    printf '%s\n' "$TEST_OLLAMA_LIST"
+    ;;
+  pull) ;;
+  create)
+    printf 'gathering model components\n'
+    printf 'writing manifest\n' >&2
+    exit "$TEST_OLLAMA_CREATE_STATUS"
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+
+  make_voice_mock curl << 'EOF'
+output=
+url=
+while [ "$#" -gt 0 ]; do
+  case $1 in
+    -o|-H|-d|--max-time) [ "$1" = -o ] && output=$2; shift 2 ;;
+    http*) url=$1; shift ;;
+    *) shift ;;
+  esac
+done
+printf 'curl %s\n' "$url" >>"$MOCK_LOG"
+case $url in
+  *huggingface.co*)
+    [ "$TEST_MODEL_CURL_STATUS" -eq 0 ] || exit "$TEST_MODEL_CURL_STATUS"
+    printf 'downloaded model bytes\n' >"$output"
+    ;;
+  */health) printf '%s' "$TEST_HEALTH_BODY" ;;
+  */chat/completions)
+    if [ "$TEST_COMPLETION_STATUS" -ne 0 ]; then
+      printf 'curl: (%s) could not reach the endpoint\n' "$TEST_COMPLETION_STATUS" >&2
+      exit "$TEST_COMPLETION_STATUS"
+    fi
+    printf '%s' "$TEST_COMPLETION_BODY"
+    ;;
+  *) exit 99 ;;
+esac
+EOF
+
+  # Per-label state on disk, so `print` reports what `bootstrap` and `kickstart`
+  # actually did.
+  make_voice_mock launchctl << 'EOF'
+printf 'launchctl %s\n' "$*" >>"$MOCK_LOG"
+action=${1:-}
+shift || true
+case $action in
+  print)
+    label=${1##*/}
+    [ "$(cat "$TEST_AGENT_DIR/$label.loaded" 2>/dev/null || printf false)" = true ] || exit 113
+    printf '%s = {\n' "$label"
+    printf '\tstate = %s\n' "$(cat "$TEST_AGENT_DIR/$label.state")"
+    printf '\tpid = %s\n' "$(cat "$TEST_AGENT_DIR/$label.pid")"
+    printf '}\n'
+    ;;
+  bootstrap)
+    label=${2##*/}
+    label=${label%.plist}
+    printf 'true\n' >"$TEST_AGENT_DIR/$label.loaded"
+    printf 'running\n' >"$TEST_AGENT_DIR/$label.state"
+    printf '9000\n' >"$TEST_AGENT_DIR/$label.pid"
+    ;;
+  kickstart)
+    [ "${1:-}" != -k ] || shift
+    label=${1##*/}
+    if [ "$TEST_KICKSTART_STATE" != unchanged ]; then
+      printf '%s\n' "$TEST_KICKSTART_STATE" >"$TEST_AGENT_DIR/$label.state"
+      printf '%s\n' "$(($(cat "$TEST_AGENT_DIR/$label.pid") + 1))" >"$TEST_AGENT_DIR/$label.pid"
+    fi
+    ;;
+  *) exit 64 ;;
+esac
+EOF
+}
+
+teardown_voice_test() {
+  rm -rf "$test_root"
+}
+
+make_voice_mock() {
+  mock_name=$1
+  mock_path=$fake_bin/$mock_name
+  {
+    printf '%s\n' '#!/bin/sh' 'set -eu'
+    cat
+  } > "$mock_path"
+  chmod +x "$mock_path"
+}
+
+set_agent_state() {
+  printf '%s\n' "$2" > "$agent_dir/$1.loaded"
+  printf '%s\n' "$3" > "$agent_dir/$1.state"
+  printf '%s\n' "$4" > "$agent_dir/$1.pid"
+}
+
+agent_field() {
+  cat "$agent_dir/$1.$2"
+}
+
+install_verified_model() {
+  mkdir -p "$model_dir"
+  printf 'existing model bytes\n' > "$model_path"
+}
+
+run_voice_setup() {
+  voice_shell=${1:-$dash_path}
+
+  run env \
+    HOME="$test_home" \
+    PATH="$fake_bin:$base_bin" \
+    MOCK_LOG="$command_log" \
+    TEST_AGENT_DIR="$agent_dir" \
+    TEST_OS="${TEST_OS:-Darwin}" \
+    TEST_NC_STATUS="${TEST_NC_STATUS:-0}" \
+    TEST_LSOF_STATUS="${TEST_LSOF_STATUS:-1}" \
+    TEST_MODEL_DIGEST="${TEST_MODEL_DIGEST:-$expected_model_sha256}" \
+    TEST_MODEL_CURL_STATUS="${TEST_MODEL_CURL_STATUS:-0}" \
+    TEST_OLLAMA_LIST="${TEST_OLLAMA_LIST-$expected_base_model}" \
+    TEST_OLLAMA_CREATE_STATUS="${TEST_OLLAMA_CREATE_STATUS:-0}" \
+    TEST_KICKSTART_STATE="${TEST_KICKSTART_STATE:-running}" \
+    TEST_HEALTH_BODY="${TEST_HEALTH_BODY-$default_health_body}" \
+    TEST_COMPLETION_STATUS="${TEST_COMPLETION_STATUS:-0}" \
+    TEST_COMPLETION_BODY="${TEST_COMPLETION_BODY-$default_completion_body}" \
+    DOTFILES_VOICE_POLL_DELAY=0 \
+    DOTFILES_VOICE_OLLAMA_ATTEMPTS="${DOTFILES_VOICE_OLLAMA_ATTEMPTS:-3}" \
+    DOTFILES_VOICE_HEALTH_ATTEMPTS="${DOTFILES_VOICE_HEALTH_ATTEMPTS:-3}" \
+    "$voice_shell" "$voice_setup"
+}
+
+assert_log_contains() {
+  if ! grep -F -- "$1" "$command_log" > /dev/null; then
+    printf 'expected command log to contain: %s\n' "$1" >&3
+    sed 's/^/  /' "$command_log" >&3
+    return 1
+  fi
+}
+
+refute_log_contains() {
+  ! grep -F -- "$1" "$command_log" > /dev/null
+}


### PR DESCRIPTION
Local, offline voice dictation for OpenCode: press ++ctrl+r++, speak, get a
cleaned prompt inserted. No audio leaves the machine.

## What this adds

Two managed LaunchAgents plus the plugin declaration:

| Service | Port | Role |
| --- | --- | --- |
| `com.shmileee.whisper-voice-server` | 8081 | whisper.cpp biased with a project vocabulary |
| `com.shmileee.ollama` | 11434 | `ollama serve` hosting a derived `voice-normalize` model |

The ~3 GB of model blobs are installed on demand by `mise run voice:setup`,
deliberately outside the Ansible run so the ephemeral macOS CI runner does not
download and discard them on every provisioning check.

ollama is declared here rather than started through `brew services`, so the
bind address, tuning flags, and log path are reviewable in the repository
instead of being whatever the formula ships. A machine that already had the
Homebrew service running needs a one-time `brew services stop ollama`.

## Notable details

- **Bind conflicts do not become abort loops.** `whisper-server` initialises
  Metal before it binds and its bind-failure path trips
  `GGML_ASSERT([rsets->data count] == 0)`, so a busy port became a SIGABRT that
  `KeepAlive` retried every 30s forever. The wrapper now pre-checks the port and
  exits 0, which `KeepAlive{SuccessfulExit=false}` reads as "stay stopped".
- **The whisper model is published atomically** behind a pinned HuggingFace
  revision and a checksum, because a truncated model degrades transcription
  instead of failing.
- **Neither log is rotated by launchd**, so each wrapper truncates its own in
  place once past a limit.
- **Renovate now tracks the OpenCode plugin pins** in `opencode.json` and
  `tui.json`. The two model pins stay frozen by hand and say why: the whisper
  checksum must be re-measured alongside the revision, and ollama tags are not
  a datasource Renovate knows.

## Verification

- `mise run test:bats` — 54/54, including 27 new tests exercising the
  provisioner under both dash and `/bin/sh`
- `mise run lint` — clean
- `mise run voice:setup` run repeatedly on a real machine; idempotent, and the
  port-conflict path verified by occupying 8081 and confirming `runs = 1`,
  `last exit code = 0`, zero aborts
- End-to-end through the real prompt:
  `"um can you run preck and then chesmoy implies"` becomes
  `"exec prek and then chezmoi apply"`
